### PR TITLE
Bump minimum Node.js version to 20.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "npm run build"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This PR updates the project's Node.js version requirements to drop support for Node.js 18.x and add support for Node.js 24.x. The minimum required Node.js version is bumped from 18.0.0 to 20.0.0.

## Changes

- Update CI test matrix to test against Node.js 20.x and 24.x (previously 18.x and 20.x)
- Bump minimum Node.js engine requirement in `package.json` from `>=18.0.0` to `>=20.0.0`

## Session Goals

- [x] Update Node.js version requirements to align with current LTS versions
- [x] Ensure CI tests against supported Node.js versions

## Success Metrics

- ✅ CI workflow tests against Node.js 20.x and 24.x
- ✅ Package.json engine field reflects new minimum version requirement
- ✅ All CI checks pass

## Testing

- [x] No linting errors
- [x] CI workflow syntax is valid

## Checklist

- [x] Code follows project style guide
- [x] No breaking changes (version bump is intentional)
- [x] All CI checks pass

## Related Issues

Closes #

https://claude.ai/code/session_01CfczKKJpHG38c4KdBDJe8U