### PR TITLE
fix: remove unused accumulator in multi-account session aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
-- TBD for next release
+- **Multi-account session tracking**: Removed an unused accumulator variable in session aggregation to resolve static analysis/code quality findings (multi-account-session-tracking-skill).
 
 ### Security
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE Agent Handoff Notes
+
+## Repo Orientation
+- There is currently no dedicated `ROADMAP.md` file in the repository root; use `RELEASE_NOTES.md`, `SESSION_SUMMARY.md`, and open PR discussions for near-term planning context.
+- Current project version is tracked in `VERSION.json`.
+- Session-oriented PR structure guidance is in `SESSION_PR_TEMPLATE.md` and `OPEN_PR_INSTRUCTIONS.md`.
+
+## Recent Stability Notes
+- PR #16 (`feature/multi-account-session-tracking-skill` into `development`) had a code-quality finding for an unused variable in session aggregation logic.
+- The unused variable `totalEnergy` in `packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts` has been removed in this session.
+
+## Execution Tips
+- Run quality checks with:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm test`
+- Lint currently reports `no-explicit-any` warnings in multi-account skill types, but no lint errors.
+
+## Guardrails
+- Never commit secrets or credentials.
+- Keep changelog (`CHANGELOG.md`) updated for every merged fix.

--- a/packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts
+++ b/packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts
@@ -24,7 +24,6 @@ export function aggregateSessions(input: AggregateSessionsInput): UnifiedDailyRe
   let totalActivities = 0;
   let totalFocusScore = 0;
   let totalTokens = 0;
-  let totalEnergy = 0;
   let totalInterruptions = 0;
 
   const accountDistribution: Record<string, any> = {};


### PR DESCRIPTION
### Motivation
- Address a code-quality/CodeQL finding tied to PR #16 by removing an unused accumulator that produced a lint error in the multi-account session aggregation logic.
- Provide minimal handoff documentation to help follow-up agents continue validation and housekeeping tasks.

### Description
- Removed the unused `totalEnergy` variable from `packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts` to satisfy static analysis. 
- Updated `CHANGELOG.md` under **[Unreleased] → Fixed** to record the remediation. 
- Added `CLAUDE.md` at the repository root with repo orientation, validation commands, and handoff notes for subsequent agents. 
- Created a PR record for the change so the updated branch can be validated and merged upstream.

### Testing
- Ran `npm run lint` and confirmed there are no lint errors (only `no-explicit-any` warnings remain). 
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully. 
- Ran `npm test` across workspaces which completed (skill packages report "No tests yet" or similar placeholders).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9cdf59c083288aca395dd29e4fb9)