### PR TITLE
chore: sync package-lock workspace entries and add CLAUDE.md with npm constraints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+## Agent Notes (2026-04-13)
+
+### Environment / Dependency Constraints
+- `npm ci` currently hangs in this environment while attempting to fetch packages and can leave partial/empty package directories under `node_modules`.
+- The npm registry endpoint is restricted in this environment (for example, `npm view @typescript-eslint/parser` returns HTTP 403).
+- Because of this, use `npm install --package-lock-only --ignore-scripts` when the immediate task is lockfile synchronization.
+
+### Current Repository State Guidance
+- `package-lock.json` needed regeneration to include workspace `@fused-gaming/skill-daily-review` at `packages/skills/daily-review-skill`.
+- CI matrix in `.github/workflows/test.yml` targets Node `20.x` and `24.x`; local validation in this environment may be blocked without a successful dependency install.
+
+### Recommended Next Steps for Next Agent
+1. Run full dependency install in an environment with npm registry access.
+2. Execute `npm ci`, `npm run lint`, `npm run typecheck`, `npm run build`, and `npm test` under Node 20 and Node 24.
+3. If any failures appear, patch and iterate until both matrix lanes pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,10 @@
       "resolved": "packages/skills/canvas-design",
       "link": true
     },
+    "node_modules/@fused-gaming/skill-daily-review": {
+      "resolved": "packages/skills/daily-review-skill",
+      "link": true
+    },
     "node_modules/@fused-gaming/skill-frontend-design": {
       "resolved": "packages/skills/frontend-design",
       "link": true
@@ -2564,6 +2568,18 @@
     },
     "packages/skills/canvas-design": {
       "name": "@fused-gaming/skill-canvas-design",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/skills/daily-review-skill": {
+      "name": "@fused-gaming/skill-daily-review",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
### Motivation
- Fix `npm ci` workspace/lockfile mismatch caused by a missing `@fused-gaming/skill-daily-review` entry and provide handoff documentation for agents operating in a restricted environment.

### Description
- Added `node_modules/@fused-gaming/skill-daily-review` link and `packages/skills/daily-review-skill` metadata to `package-lock.json` to restore workspace/lockfile sync, and added `CLAUDE.md` documenting npm registry constraints and next-agent steps; both files were committed and a PR was created.

### Testing
- Ran `npm install --package-lock-only --ignore-scripts` which regenerated lockfile metadata successfully; `npm ci` initially failed due to the missing workspace entry prior to the fix; `npm ci` and full install remain blocked/hang in this environment due to registry restrictions (HTTP 403), and `npm run typecheck`/`npm run lint` cannot fully pass locally without a successful dependency install.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9b1bec288328bc334e45018f6cd3)