### PR TITLE
fix: synchronize npm lockfile for multi-account workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@
 - The unused variable `totalEnergy` in `packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts` has been removed in this session.
 
 ## Execution Tips
+- CI `npm ci` can fail with EUSAGE if a new workspace package is added but root `package-lock.json` is not regenerated. Run `npm install` at repo root and commit the lockfile update.
 - Run quality checks with:
   - `npm run lint`
   - `npm run typecheck`

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,10 @@
       "resolved": "packages/skills/mcp-builder",
       "link": true
     },
+    "node_modules/@fused-gaming/skill-multi-account-session-tracking": {
+      "resolved": "packages/skills/multi-account-session-tracking-skill",
+      "link": true
+    },
     "node_modules/@fused-gaming/skill-pre-deploy-validator": {
       "resolved": "packages/skills/pre-deploy-validator",
       "link": true
@@ -2599,6 +2603,18 @@
       },
       "devDependencies": {
         "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/skills/multi-account-session-tracking-skill": {
+      "name": "@fused-gaming/skill-multi-account-session-tracking",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
         "typescript": "^5.3.2"
       }
     },


### PR DESCRIPTION
### Motivation
- Ensure `npm ci` works in CI and locally by making the root `package-lock.json` reflect the added workspace package `@fused-gaming/skill-multi-account-session-tracking`, and add a handoff note to prevent recurrence.

### Description
- Updated `package-lock.json` to include the linked workspace entry for `@fused-gaming/skill-multi-account-session-tracking` and updated `CLAUDE.md` with guidance to run `npm install` and commit the lockfile when new workspace packages are added.

### Testing
- Ran `npm install`/`npm ci` after regenerating the lockfile and `npm ci` completed successfully; `npm run lint` completed with 8 warnings (no errors); and `npm run typecheck` (`tsc --noEmit`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9f812fbc8328ba990d2516076110)