### PR TITLE
fix: stabilize CI matrix by removing any-typed session aggregation models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Multi-account session tracking**: Removed an unused accumulator variable in session aggregation to resolve static analysis/code quality findings (multi-account-session-tracking-skill).
+- **Multi-account session tracking**: Replaced `any` typing in daily review/session aggregation models with explicit typed records to remove lint warnings that can break stricter CI gates (multi-account-session-tracking-skill).
 
 ### Security
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,10 @@
   - `npm run lint`
   - `npm run typecheck`
   - `npm test`
-- Lint currently reports `no-explicit-any` warnings in multi-account skill types, but no lint errors.
+- Keep `VERSION.json` runtime requirements aligned with `package.json` engines (currently Node >=20).
+
+## Environment Constraints
+- GitHub REST API and anonymous PR listing can return `403 Forbidden` in this execution environment; when that happens, rely on local files (`SESSION_SUMMARY.md`, `OPEN_PR_INSTRUCTIONS.md`, git history) for orientation and explicitly call out the API-access blocker.
 
 ## Guardrails
 - Never commit secrets or credentials.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ npm run typecheck   # Validate TypeScript
 npm run dev         # Start dev server
 ```
 
+> CI tip: keep lint output warning-free in addition to error-free to avoid stricter pipeline gates in downstream environments.
+
 ---
 
 ## 📚 Documentation

--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -1,5 +1,12 @@
 # Session Summary: Complete Project Delivery with Proper Branching
 
+## Update: 2026-04-13 — CI Stabilization (Node Matrix)
+
+- Removed `any` types from multi-account session aggregation/review models to eliminate lint warnings that can fail stricter CI policies.
+- Verified `npm ci`, `npm run lint`, `npm run typecheck`, `npm run build`, and `npm test` all pass locally.
+- Aligned `VERSION.json` Node minimum metadata with package engines (Node >=20).
+- Added environment note in `CLAUDE.md` documenting GitHub API `403` limitations for unauthenticated PR discovery in this runtime.
+
 **Date:** April 1, 2026  
 **Duration:** Single comprehensive session  
 **Status:** ✅ COMPLETE  

--- a/VERSION.json
+++ b/VERSION.json
@@ -7,7 +7,7 @@
   "patchVersion": 0,
   "prerelease": null,
   "metadata": {
-    "nodeMinimum": "18.0.0",
+    "nodeMinimum": "20.0.0",
     "npmMinimum": "8.0.0",
     "typescriptVersion": "5.3.2",
     "buildNumber": 1001

--- a/packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts
+++ b/packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts
@@ -26,7 +26,7 @@ export function aggregateSessions(input: AggregateSessionsInput): UnifiedDailyRe
   let totalTokens = 0;
   let totalInterruptions = 0;
 
-  const accountDistribution: Record<string, any> = {};
+  const accountDistribution: MultiAccountMetrics['account_distribution'] = {};
   const focusComparison: Record<string, number> = {};
   const accomplishmentsByAccount: Record<string, string[]> = {};
 

--- a/packages/skills/multi-account-session-tracking-skill/src/types.ts
+++ b/packages/skills/multi-account-session-tracking-skill/src/types.ts
@@ -130,10 +130,10 @@ export interface UnifiedDailyReview {
   review_period: string;
   accounts_tracked: number;
   total_combined_duration_minutes: number;
-  accounts: Record<string, any>;
+  accounts: Record<string, AccountSessions>;
   unified_metrics: MultiAccountMetrics;
   accomplishments_by_account: Record<string, string[]>;
-  blockers_by_account: Record<string, any[]>;
+  blockers_by_account: Record<string, string[]>;
   next_day_priorities: {
     primary?: string[];
     secondary?: string[];
@@ -141,17 +141,17 @@ export interface UnifiedDailyReview {
   };
   cross_account_analysis: {
     specialization_effectiveness: string;
-    session_distribution: any;
-    productivity_correlation: any;
+    session_distribution: Record<string, number>;
+    productivity_correlation: Record<string, number>;
     optimization_recommendations: string[];
   };
 }
 
 export interface WeeklyProjection {
   if_maintaining_current_pace: {
-    primary_week?: any;
-    secondary_week?: any;
-    combined_week?: any;
+    primary_week?: Record<string, number | string>;
+    secondary_week?: Record<string, number | string>;
+    combined_week?: Record<string, number | string>;
   };
 }
 


### PR DESCRIPTION
### Motivation
- CI matrix jobs using Node `20.x`/`24.x` were being blocked by lint/type-safety warnings caused by `any`-typed model fields in the multi-account session tracking domain, which can cause stricter pipelines to fail or be canceled.
- The repository runtime metadata in `VERSION.json` needed to match the documented engine requirements to avoid environment mismatches during CI runs.
- Documentation and agent handoff notes needed updates to reflect the stabilization changes and environment constraints for future agents.

### Description
- Replaced loose `any` usages in `packages/skills/multi-account-session-tracking-skill/src/types.ts` with explicit typed records such as `Record<string, AccountSessions>` and `Record<string, number>` to remove lint warnings. 
- Tightened aggregation typing in `packages/skills/multi-account-session-tracking-skill/src/tools/session-aggregation.ts` by changing `Record<string, any>` to `MultiAccountMetrics['account_distribution']` to ensure consistent per-account metrics typing. 
- Aligned runtime metadata by updating `VERSION.json` `nodeMinimum` from `18.0.0` to `20.0.0` to match `package.json` engines and README badges. 
- Updated documentation and handoff artifacts by editing `CHANGELOG.md`, `README.md`, `SESSION_SUMMARY.md`, and `CLAUDE.md` to record the fix, add CI advice, and note GitHub API access constraints for unauthenticated environments. 

### Testing
- Ran `npm ci` and `npm run build` across workspaces and the builds completed successfully. 
- Ran `npm run lint` and `npm run typecheck` and both completed successfully with lint warnings removed from the multi-account session tracking code. 
- Ran `npm test` (workspace test runner) and the workspace test commands executed (packages currently echo placeholder messages) with no failures. 
- The combined validation command `npm run lint && npm run typecheck && npm run build && npm test` completed successfully in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca2d5babc8328af4141bd571e29ba)