### PR TITLE
ci: migrate GitHub Actions to Node24-compatible action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Changed
-- TBD for next release
+- **CI/CD**: Updated GitHub Actions to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) and disabled matrix fail-fast in `test.yml` so Node 24 jobs still run when Node 20 fails.
 
 ### Deprecated
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
   - `npm run typecheck`
   - `npm test`
 - Keep `VERSION.json` runtime requirements aligned with `package.json` engines (currently Node >=20).
+- GitHub Actions Node runtime migration is active: prefer `actions/checkout@v5` and `actions/setup-node@v5` to avoid Node 20 deprecation warnings and upcoming forced Node 24 execution behavior.
 
 ## Environment Constraints
 - GitHub REST API and anonymous PR listing can return `403 Forbidden` in this execution environment; when that happens, rely on local files (`SESSION_SUMMARY.md`, `OPEN_PR_INSTRUCTIONS.md`, git history) for orientation and explicitly call out the API-access blocker.


### PR DESCRIPTION
### Motivation
- Address deprecation warnings and failing test jobs caused by actions running on the Node.js 20 runtime and ensure the CI matrix still reports results for Node 24 when Node 20 fails. 
- Make workflows consistent and future-proof by using Node 24-compatible major versions of core actions.

### Description
- Updated core workflow actions from `actions/checkout@v4` to `actions/checkout@v5` in `/.github/workflows/test.yml`, `/.github/workflows/publish.yml`, and `/.github/workflows/codeql.yml` to avoid Node 20 deprecation warnings. 
- Updated `actions/setup-node@v4` to `actions/setup-node@v5` in `/.github/workflows/test.yml` and `/.github/workflows/publish.yml` to ensure compatibility with Node 24. 
- Added `fail-fast: false` to the `test` job matrix in `/.github/workflows/test.yml` so the `24.x` matrix job still runs and reports even if `20.x` fails. 
- Documented the CI migration in `CHANGELOG.md` and added a runtime-migration note to `CLAUDE.md` so future agents and maintainers are aware of the change. 

### Testing
- Ran `npm ci` and workspace build which completed successfully and installed all packages. 
- Ran `npm run lint --if-present` and `npm run typecheck --if-present` which succeeded with no lint or type errors. 
- Ran `npm run build --if-present` for workspaces and `npm test --if-present --workspaces` which executed the package test scripts (all packages returned their expected placeholder outputs and no test failures occurred).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca5e38d508328ac826c731793d1df)