### PR TITLE
ci: migrate workflows to Node 24-compatible GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [20.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,13 @@
 1. Re-run GitHub Actions for the current branch to confirm `Install dependencies` passes on both Node matrix lanes.
 2. Execute `npm run lint`, `npm run typecheck`, `npm run build`, and `npm test` in an environment with full npm registry access.
 3. If failures appear, patch and iterate until both matrix lanes pass.
+
+## Agent Notes (2026-04-13, Node 24 Actions Migration)
+
+### CI / Actions Compatibility
+- Updated GitHub Actions references from `actions/checkout@v4` to `actions/checkout@v5` and `actions/setup-node@v4` to `actions/setup-node@v5` in test, publish, and codeql workflows.
+- This removes the runner deprecation warnings about JavaScript actions pinned to Node.js 20 and aligns workflows with Node.js 24 action runtime migration.
+
+### Follow-up Verification
+1. Re-run `Test` workflow matrix (`20.x`, `24.x`) and verify no Node 20 deprecation warnings remain.
+2. Re-run `CodeQL Advanced` and `Publish to npm` workflow checks on PR to confirm upgraded actions are accepted.


### PR DESCRIPTION
### Motivation
- CI logs showed deprecation warnings caused by JavaScript actions pinned to Node.js 20, so workflows need to use action releases compatible with the Node 24 action runtime migration.
- Aligning workflow action versions reduces future CI breakage and noise from runner deprecation warnings.

### Description
- Replaced `actions/checkout@v4` with `actions/checkout@v5` in `.github/workflows/test.yml`, `.github/workflows/publish.yml`, and `.github/workflows/codeql.yml`.
- Replaced `actions/setup-node@v4` with `actions/setup-node@v5` in `.github/workflows/test.yml` and `.github/workflows/publish.yml` to adopt Node 24-compatible action releases.
- Added migration and verification notes to `CLAUDE.md` documenting the change and follow-up validation steps.
- Kept existing workflow steps (lockfile sync, `npm ci`, lint/typecheck/build/test) unchanged to preserve current CI behavior.

### Testing
- Ran `npm install --package-lock-only --ignore-scripts` which completed successfully.
- Ran `npm ci` and the workspace `build` lifecycle which completed successfully (packages built via `tsc`).
- Ran `npm run lint --if-present`, `npm run typecheck --if-present`, `npm run build --if-present`, and `npm test --if-present --workspaces`, all of which completed successfully in the local environment (many packages report `No tests yet`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca65c0b788328b1d2c2c865ae43b9)