### PR TITLE
ci: force Node 24 for JavaScript actions and update deprecated action refs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,9 @@ on:
   schedule:
     - cron: '28 5 * * 2'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - "v*"
       - "skill-*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **CI/CD**: Updated GitHub Actions to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) and disabled matrix fail-fast in `test.yml` so Node 24 jobs still run when Node 20 fails.
+- **CI/CD**: Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in repository workflows (`test`, `publish`, `codeql`) to proactively validate JavaScript-based actions on Node 24 before the June 2, 2026 default switch.
+- **Docs**: Updated embedded workflow examples and action-version guidance from `@v4` to `@v5` across publishing/execution/prompt/manifest docs for consistency with live CI configuration.
 
 ### Deprecated
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
   - `npm test`
 - Keep `VERSION.json` runtime requirements aligned with `package.json` engines (currently Node >=20).
 - GitHub Actions Node runtime migration is active: prefer `actions/checkout@v5` and `actions/setup-node@v5` to avoid Node 20 deprecation warnings and upcoming forced Node 24 execution behavior.
+- For transition-period stability, keep `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` set in workflow `env` so action-runtime regressions surface before Node 24 becomes mandatory.
 
 ## Environment Constraints
 - GitHub REST API and anonymous PR listing can return `403 Forbidden` in this execution environment; when that happens, rely on local files (`SESSION_SUMMARY.md`, `OPEN_PR_INSTRUCTIONS.md`, git history) for orientation and explicitly call out the API-access blocker.

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -184,12 +184,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'

--- a/fused-gaming-mcp-execution.md
+++ b/fused-gaming-mcp-execution.md
@@ -160,8 +160,8 @@
        test:
          runs-on: ubuntu-latest
          steps:
-           - uses: actions/checkout@v4
-           - uses: actions/setup-node@v4
+           - uses: actions/checkout@v5
+           - uses: actions/setup-node@v5
            - run: npm ci
            - run: npm run lint
            - run: npm run build
@@ -180,8 +180,8 @@
        publish:
          runs-on: ubuntu-latest
          steps:
-           - uses: actions/checkout@v4
-           - uses: actions/setup-node@v4
+           - uses: actions/checkout@v5
+           - uses: actions/setup-node@v5
            - run: npm ci
            - run: npm run build
            - run: npm publish --workspaces

--- a/fused-gaming-mcp-manifest.md
+++ b/fused-gaming-mcp-manifest.md
@@ -473,8 +473,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org
@@ -502,7 +502,7 @@ jobs:
   submit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate MCP metadata
         run: npm run gen:mcp-metadata
       - name: Create PR to MCP registry

--- a/fused-gaming-mcp-prompts.md
+++ b/fused-gaming-mcp-prompts.md
@@ -242,8 +242,8 @@ FILES:
    - Post success message (optional)
 
 REQUIREMENTS:
-- Use actions/checkout@v4
-- Use actions/setup-node@v4
+- Use actions/checkout@v5
+- Use actions/setup-node@v5
 - Fail fast on errors
 - Clear job names
 - Optional: codecov or coverage reporting


### PR DESCRIPTION
### Motivation
- Prevent upcoming GitHub Actions Node 20 deprecation issues by exercising JavaScript actions on Node 24 ahead of the mandatory switchover. 
- Remove stale documentation/examples that reference deprecated `@v4` action majors to avoid confusion and regressions. 

### Description
- Added `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to ` .github/workflows/test.yml`, `.github/workflows/publish.yml`, and `.github/workflows/codeql.yml` to force JavaScript-based actions to run on Node 24. 
- Replaced `actions/checkout@v4` and `actions/setup-node@v4` references with `actions/checkout@v5` and `actions/setup-node@v5` in `docs/NPM_PUBLISHING.md`, `fused-gaming-mcp-prompts.md`, `fused-gaming-mcp-manifest.md`, and `fused-gaming-mcp-execution.md`. 
- Updated operational guidance in `CHANGELOG.md` and `CLAUDE.md` to document the Node 24 enforcement and sync the docs with live CI configuration. 

### Testing
- Verified no remaining `actions/checkout@v4` or `actions/setup-node@v4` occurrences in the updated workflow/doc targets using `rg` (no matches). 
- Ran `npm run lint --if-present` and the linter completed successfully. 
- Ran `npm run typecheck --if-present` and TypeScript checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcafe9c8f88328ad539d1af4d05db2)