### PR TITLE
ci: publish npm workspaces on main pushes and add manual dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,13 +2,19 @@ name: Publish to npm
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
       - "skill-*"
+  workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -33,8 +39,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish to npm
-        run: npm publish --workspaces
+      - name: Publish workspaces to npm
+        run: npm publish --workspaces --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -42,7 +48,7 @@ jobs:
         uses: actions/create-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Changed
-- TBD for next release
+- Updated `publish.yml` to publish npm workspaces on every push to `main` (including merges), while retaining tag-triggered releases and adding manual `workflow_dispatch` support.
+- Switched GitHub release authentication in the publish workflow to use the repository `GH_TOKEN` secret.
 
 ### Deprecated
 - TBD for next release


### PR DESCRIPTION
### Motivation
- Ensure npm packages are published automatically on merges/pushes to `main` (in addition to tag-triggered releases) and provide a manual trigger for recoverability. 
- Use repository secrets for authentication so CI can publish workspaces securely with `NPM_TOKEN` and create releases with `GH_TOKEN`.

### Description
- Updated `.github/workflows/publish.yml` to trigger on pushes to `main`, retain tag-based triggers, and add `workflow_dispatch` for manual runs. 
- Added `permissions: contents: write` and `id-token: write` to the publish job and switched GitHub release authentication to use the repository secret `GH_TOKEN`. 
- Adjusted the publish step to `npm publish --workspaces --access public` while keeping npm auth via `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`. 
- Updated `CHANGELOG.md` under `Unreleased` to document the CI/CD workflow change. 

### Testing
- Ran `npm run lint` and the lint step completed successfully. 
- Ran `npm run typecheck` and TypeScript compilation (`tsc --noEmit`) completed successfully. 
- Ran `npm run build` which built all workspaces successfully. 
- Attempted to query GitHub PRs/status via the `gh` CLI and the GitHub API but those checks failed due to the environment lacking `gh` and having network/API restrictions, so remote PR/test status could not be validated in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb30253a083288b3f7abc57e2a3cc)