### PR TITLE
fix(ci): make npm workspace publishing resilient to missing scopes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,17 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Prepare package scope for publishing
+        run: |
+          if [ -z "${NPM_SCOPE}" ]; then
+            export NPM_SCOPE=$(npm whoami)
+          fi
+          echo "Publishing with scope: @${NPM_SCOPE#@}"
+          node scripts/prepare-publish-scope.js
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_SCOPE: ${{ vars.NPM_SCOPE }}
+
       - name: Publish workspaces to npm
         run: npm publish --workspaces --access public
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
-- TBD for next release
+- Prevented npm publish workflow failures from missing scopes by adding CI scope preparation with `NPM_SCOPE` override and `npm whoami` fallback.
 
 ### Security
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE Agent Notes
+
+## Publishing gotcha
+- `npm publish --workspaces --access public` can fail with `E404 Scope not found` when the configured package scope does not exist for the npm token owner.
+- CI workflow now runs `scripts/prepare-publish-scope.js` before publish.
+- Preferred configuration: set GitHub Actions variable `NPM_SCOPE` (without `@`) for org publishing.
+- Fallback behavior: if `NPM_SCOPE` is unset, workflow uses `npm whoami` scope.
+
+## Next-agent checklist
+1. Validate that `NPM_SCOPE` is configured in repository variables for official releases.
+2. For forks, leave `NPM_SCOPE` unset to use token-owner scope automatically.
+3. Keep CHANGELOG and publishing docs updated whenever release automation changes.

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -156,6 +156,15 @@ git push origin v1.1.0
 # Update version and releaseDate
 ```
 
+## Scope Selection in CI
+
+To avoid `E404 Scope not found` during workspace publishing:
+
+- Set repository variable `NPM_SCOPE` to force an org/user scope (for example `fused-gaming`).
+- If `NPM_SCOPE` is not set, the workflow falls back to `npm whoami` and publishes using the token owner's scope.
+
+This allows forks and contributor tokens to publish without rewriting package manifests manually.
+
 ## Automated CI/CD
 
 ### GitHub Actions Setup

--- a/scripts/prepare-publish-scope.js
+++ b/scripts/prepare-publish-scope.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const rootDir = process.cwd();
+const rootPkgPath = path.join(rootDir, 'package.json');
+const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf8'));
+
+const rawScope = process.env.NPM_SCOPE?.trim();
+if (!rawScope) {
+  console.log('NPM_SCOPE not set; keeping existing package names.');
+  process.exit(0);
+}
+
+const normalizedScope = rawScope.replace(/^@/, '');
+if (!normalizedScope) {
+  console.error('NPM_SCOPE is empty after normalization.');
+  process.exit(1);
+}
+
+const scopePrefix = `@${normalizedScope}/`;
+const workspacePatterns = Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : [];
+
+const packageFiles = [rootPkgPath];
+for (const pattern of workspacePatterns) {
+  if (pattern.endsWith('/*')) {
+    const dir = path.join(rootDir, pattern.slice(0, -2));
+    if (!fs.existsSync(dir)) continue;
+    for (const entry of fs.readdirSync(dir)) {
+      const pkgPath = path.join(dir, entry, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        packageFiles.push(pkgPath);
+      }
+    }
+  } else {
+    const pkgPath = path.join(rootDir, pattern, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      packageFiles.push(pkgPath);
+    }
+  }
+}
+
+const renameMap = new Map();
+const packageJsons = packageFiles.map((pkgPath) => {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  if (typeof pkg.name === 'string' && pkg.name.includes('/')) {
+    const oldName = pkg.name;
+    const unscopedName = oldName.split('/').slice(1).join('/');
+    const newName = `${scopePrefix}${unscopedName}`;
+    renameMap.set(oldName, newName);
+    pkg.name = newName;
+  }
+  return { pkgPath, pkg };
+});
+
+for (const item of packageJsons) {
+  for (const depField of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    const deps = item.pkg[depField];
+    if (!deps || typeof deps !== 'object') continue;
+
+    for (const [depName, depVersion] of Object.entries(deps)) {
+      const remappedName = renameMap.get(depName);
+      if (remappedName) {
+        delete deps[depName];
+        deps[remappedName] = depVersion;
+      }
+    }
+  }
+
+  fs.writeFileSync(item.pkgPath, `${JSON.stringify(item.pkg, null, 2)}\n`);
+}
+
+console.log(`Prepared ${packageJsons.length} package manifests for scope ${scopePrefix}`);


### PR DESCRIPTION
### Motivation
- Publishing workspaces with a token that doesn't own the configured org scope caused `E404 Scope not found` failures during `npm publish --workspaces`.
- CI needs a safe way to publish from forks or contributor tokens without manual manifest edits.
- The change centralizes a deterministic scope selection and manifest remapping step in CI to avoid publish hard-fails.

### Description
- Added `scripts/prepare-publish-scope.js` to remap workspace `package.json` names and internal dependency keys to a chosen scope at publish time (reads `NPM_SCOPE`).
- Updated `.github/workflows/publish.yml` to run a pre-publish step that sets `NPM_SCOPE` from repo variable `vars.NPM_SCOPE` or falls back to `npm whoami`, then runs `node scripts/prepare-publish-scope.js` before `npm publish --workspaces`.
- Documented the CI scope selection and fallback behavior in `docs/NPM_PUBLISHING.md` and updated `CHANGELOG.md` under **Unreleased → Fixed**.
- Added `CLAUDE.md` with agent handoff notes and next-agent checklist explaining the scope behavior.

### Testing
- Ran `npm run build` across workspaces and it completed successfully.
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully.
- Ran `npm run lint` and it completed successfully.
- Executed `node scripts/prepare-publish-scope.js` locally with no `NPM_SCOPE` set and confirmed the script exits cleanly with the expected no-op message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcba215414832895ac7b6dab48c6e5)