### PR TITLE
fix(deps): resync package-lock after development merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Prevented npm publish workflow failures from missing scopes by adding CI scope preparation with `NPM_SCOPE` override and `npm whoami` fallback.
+- Regenerated `package-lock.json` to include newly scaffolded workspace packages so `npm ci` no longer fails after development→main merges.
 
 ### Security
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,4 @@
 6. Public npm publication currently uses `@h4shed/*`; keep release-facing docs aligned with that scope until org scope changes.
 7. Skill inventory, missing skills, and backlog planning are tracked in `docs/ROADMAP.md`; update it whenever release priorities change.
 8. New skill scaffolds now exist under `packages/skills/` for mermaid-terminal, ux-journeymapper, svg-generator, project-manager, project-status-tool, daily-review, multi-account-session-tracking, and linkedin-master-journalist.
+9. If `npm ci` fails with missing workspace packages after merges, run `npm install` at repo root to regenerate `package-lock.json`, then re-run `npm ci` to verify lockfile sync.

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@fused-gaming/multi-account-session-tracking": {
+      "resolved": "packages/skills/multi-account-session-tracking",
+      "link": true
+    },
     "node_modules/@fused-gaming/skill-algorithmic-art": {
       "resolved": "packages/skills/algorithmic-art",
       "link": true
@@ -139,20 +143,44 @@
       "resolved": "packages/skills/canvas-design",
       "link": true
     },
+    "node_modules/@fused-gaming/skill-daily-review": {
+      "resolved": "packages/skills/daily-review",
+      "link": true
+    },
     "node_modules/@fused-gaming/skill-frontend-design": {
       "resolved": "packages/skills/frontend-design",
+      "link": true
+    },
+    "node_modules/@fused-gaming/skill-linkedin-master-journalist": {
+      "resolved": "packages/skills/linkedin-master-journalist",
       "link": true
     },
     "node_modules/@fused-gaming/skill-mcp-builder": {
       "resolved": "packages/skills/mcp-builder",
       "link": true
     },
+    "node_modules/@fused-gaming/skill-mermaid-terminal": {
+      "resolved": "packages/skills/mermaid-terminal",
+      "link": true
+    },
     "node_modules/@fused-gaming/skill-pre-deploy-validator": {
       "resolved": "packages/skills/pre-deploy-validator",
       "link": true
     },
+    "node_modules/@fused-gaming/skill-project-manager": {
+      "resolved": "packages/skills/project-manager",
+      "link": true
+    },
+    "node_modules/@fused-gaming/skill-project-status-tool": {
+      "resolved": "packages/skills/project-status-tool",
+      "link": true
+    },
     "node_modules/@fused-gaming/skill-skill-creator": {
       "resolved": "packages/skills/skill-creator",
+      "link": true
+    },
+    "node_modules/@fused-gaming/skill-svg-generator": {
+      "resolved": "packages/skills/svg-generator",
       "link": true
     },
     "node_modules/@fused-gaming/skill-theme-factory": {
@@ -161,6 +189,10 @@
     },
     "node_modules/@fused-gaming/skill-underworld-writer": {
       "resolved": "packages/skills/underworld-writer-skill",
+      "link": true
+    },
+    "node_modules/@fused-gaming/skill-ux-journeymapper": {
+      "resolved": "packages/skills/ux-journeymapper",
       "link": true
     },
     "node_modules/@hono/node-server": {
@@ -2578,8 +2610,32 @@
         "typescript": "^5.3.2"
       }
     },
+    "packages/skills/daily-review": {
+      "name": "@fused-gaming/skill-daily-review",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
     "packages/skills/frontend-design": {
       "name": "@fused-gaming/skill-frontend-design",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/skills/linkedin-master-journalist": {
+      "name": "@fused-gaming/skill-linkedin-master-journalist",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2602,6 +2658,30 @@
         "typescript": "^5.3.2"
       }
     },
+    "packages/skills/mermaid-terminal": {
+      "name": "@fused-gaming/skill-mermaid-terminal",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/skills/multi-account-session-tracking": {
+      "name": "@fused-gaming/multi-account-session-tracking",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
     "packages/skills/pre-deploy-validator": {
       "name": "@fused-gaming/skill-pre-deploy-validator",
       "version": "1.0.0",
@@ -2614,8 +2694,44 @@
         "typescript": "^5.3.2"
       }
     },
+    "packages/skills/project-manager": {
+      "name": "@fused-gaming/skill-project-manager",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/skills/project-status-tool": {
+      "name": "@fused-gaming/skill-project-status-tool",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
     "packages/skills/skill-creator": {
       "name": "@fused-gaming/skill-skill-creator",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/skills/svg-generator": {
+      "name": "@fused-gaming/skill-svg-generator",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2640,6 +2756,18 @@
     },
     "packages/skills/underworld-writer-skill": {
       "name": "@fused-gaming/skill-underworld-writer",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fused-gaming/mcp-core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/skills/ux-journeymapper": {
+      "name": "@fused-gaming/skill-ux-journeymapper",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
### Motivation
- A recent merge added scaffolded workspace packages which caused `npm ci` to fail due to the root `package-lock.json` missing those workspaces. 
- Restoring a lockfile that contains the new workspace entries is required to make installs deterministic and CI reproducible. 
- The change also captures the fix in project docs so future agents know the recovery step for this class of failure.

### Description
- Regenerated the root `package-lock.json` so newly scaffolded workspaces (e.g. `@fused-gaming/multi-account-session-tracking`, `@fused-gaming/skill-daily-review`, `@fused-gaming/skill-project-manager`) are included. 
- Updated `CHANGELOG.md` under `Unreleased` → `Fixed` to record the lockfile resync. 
- Appended a recovery note to `CLAUDE.md` advising to run `npm install` at the repo root and then re-run `npm ci` when `npm ci` fails with missing workspace packages. 
- Files changed: `package-lock.json`, `CHANGELOG.md`, and `CLAUDE.md`.

### Testing
- Reproduced the failure: `npm ci` initially failed with missing-workspace-package errors. (failed)
- Recovery: ran `npm install` at the repository root to regenerate the lockfile, after which `npm ci` completed successfully. (succeeded)
- Ran workspace tests with `npm test` which executed the per-package test scripts (all workspaces reported "No tests yet"). (succeeded)
- Verified the lockfile contains the new workspace entries using a search (e.g. `rg -n "multi-account-session-tracking|skill-daily-review|skill-project-manager" package-lock.json`). (succeeded)
- Note: GitHub CLI (`gh`) is not available in this environment, so live PR/check-run statuses could not be queried here. (informational)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccab8612c832891af4528c9110a74)