### PR TITLE
docs(ci): migrate GitHub Actions examples to v5 for Node 24 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
-- TBD for next release
+- Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.
 
 ### Security
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,6 @@
 ### Follow-up Verification
 1. Re-run `Test` workflow matrix (`20.x`, `24.x`) and verify no Node 20 deprecation warnings remain.
 2. Re-run `CodeQL Advanced` and `Publish to npm` workflow checks on PR to confirm upgraded actions are accepted.
+
+### Documentation Drift Prevention
+- Keep GitHub Actions examples in `docs/NPM_PUBLISHING.md`, `fused-gaming-mcp-manifest.md`, `fused-gaming-mcp-prompts.md`, and `fused-gaming-mcp-execution.md` aligned with live workflows to avoid reintroducing deprecated `@v4` references.

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -184,12 +184,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'

--- a/fused-gaming-mcp-execution.md
+++ b/fused-gaming-mcp-execution.md
@@ -160,8 +160,8 @@
        test:
          runs-on: ubuntu-latest
          steps:
-           - uses: actions/checkout@v4
-           - uses: actions/setup-node@v4
+           - uses: actions/checkout@v5
+           - uses: actions/setup-node@v5
            - run: npm ci
            - run: npm run lint
            - run: npm run build
@@ -180,8 +180,8 @@
        publish:
          runs-on: ubuntu-latest
          steps:
-           - uses: actions/checkout@v4
-           - uses: actions/setup-node@v4
+           - uses: actions/checkout@v5
+           - uses: actions/setup-node@v5
            - run: npm ci
            - run: npm run build
            - run: npm publish --workspaces

--- a/fused-gaming-mcp-manifest.md
+++ b/fused-gaming-mcp-manifest.md
@@ -473,8 +473,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org
@@ -502,7 +502,7 @@ jobs:
   submit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate MCP metadata
         run: npm run gen:mcp-metadata
       - name: Create PR to MCP registry

--- a/fused-gaming-mcp-prompts.md
+++ b/fused-gaming-mcp-prompts.md
@@ -242,8 +242,8 @@ FILES:
    - Post success message (optional)
 
 REQUIREMENTS:
-- Use actions/checkout@v4
-- Use actions/setup-node@v4
+- Use actions/checkout@v5
+- Use actions/setup-node@v5
 - Fail fast on errors
 - Clear job names
 - Optional: codecov or coverage reporting


### PR DESCRIPTION
### Motivation
- GitHub is deprecating JavaScript actions pinned to Node.js 20, so documentation and template examples must reference Node 24-compatible action major versions to avoid future breakage and deprecation warnings.

### Description
- Updated `docs/NPM_PUBLISHING.md`, `fused-gaming-mcp-prompts.md`, `fused-gaming-mcp-manifest.md`, and `fused-gaming-mcp-execution.md` to replace `actions/checkout@v4` with `actions/checkout@v5` and `actions/setup-node@v4` with `actions/setup-node@v5` in example workflows and templates.
- Recorded the migration in the `CHANGELOG.md` Unreleased section under `Fixed` to document the action runtime alignment.
- Added a `Documentation Drift Prevention` note to `CLAUDE.md` to guide future contributors to keep workflow examples synchronized with live workflows.
- Performed a scripted sweep to normalize references in targeted docs and applied the replacements across those files.

### Testing
- Ran `npm run lint --if-present` which completed successfully and reported no new lint failures.
- Executed a scripted scan that verified there are `0` remaining references to `actions/checkout@v4` or `actions/setup-node@v4` in the targeted files.
- Attempted `gh pr list --limit 5` which failed due to the environment missing the `gh` CLI, so remote PR listing was not available.
- Used the lint and the automated scan as the primary validation steps and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcafd66f1c8328945a8ec98e43a260)