### PR TITLE
Add auto-bump and preflight publish checks and wire into publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,15 +30,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint --if-present
-
-      - name: Typecheck
-        run: npm run typecheck --if-present
-
-      - name: Build
-        run: npm run build
-
       - name: Prepare package scope for publishing
         run: |
           if [ -z "${NPM_SCOPE}" ]; then
@@ -49,6 +40,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_SCOPE: ${{ vars.NPM_SCOPE }}
+
+      - name: Auto-bump workspace versions for npm publish
+        run: node scripts/auto-bump-publish-versions.js
+
+      - name: Preflight publish version check
+        run: node scripts/preflight-publish-check.js
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Typecheck
+        run: npm run typecheck --if-present
+
+      - name: Build
+        run: npm run build
 
       - name: Publish workspaces to npm
         run: npm publish --workspaces --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `scripts/auto-bump-publish-versions.js` to automatically patch-bump root/workspace package versions until npm reports they are publishable.
+- Added `scripts/preflight-publish-check.js` and wired it into publish CI to fail fast when any workspace package version is already published on npm.
 - Added a documentation index (`docs/README.md`) and reorganized root-level docs into categorized directories (`docs/getting-started`, `docs/process`, `docs/releases`, `docs/archive`).
 - Added a dedicated GitHub release workflow (`.github/workflows/github-release.yml`) that triggers on release tags (`v*`, `skill-*`) and can also be started manually.
 - Added a roadmap document (`docs/ROADMAP.md`) with published/missing/planned skill inventories, blockers, and immediate next steps.
 - Added scaffold packages for upcoming skills: mermaid-terminal, ux-journeymapper, svg-generator, project-manager, project-status-tool, daily-review, multi-account-session-tracking, and linkedin-master-journalist.
 
 ### Changed
+- Added publish helper scripts `publish:auto-bump` and `publish:prepare` for automated version-bump + duplicate-version verification.
 - Updated README and package publish file list to reflect the new documentation paths.
 - Updated `publish.yml` to publish npm workspaces on every push to `main` (including merges), while retaining tag-triggered releases and adding manual `workflow_dispatch` support.
 - Switched GitHub release authentication in the publish workflow to use the repository `GH_TOKEN` secret.
@@ -28,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Automated duplicate-version recovery in CI so workspace publishes no longer require manual per-package version tracking before publish.
+- Prevented wasted publish pipeline compute by running npm duplicate-version checks before lint/typecheck/build in `publish.yml`.
 - Prevented npm publish workflow failures from missing scopes by adding CI scope preparation with `NPM_SCOPE` override and `npm whoami` fallback.
 - Regenerated `package-lock.json` to include newly scaffolded workspace packages so `npm ci` no longer fails after development→main merges.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,6 @@
 9. If `npm ci` fails with missing workspace packages after merges, run `npm install` at repo root to regenerate `package-lock.json`, then re-run `npm ci` to verify lockfile sync.
 
 10. Root documentation was reorganized into categorized folders under `docs/`; place new process docs in `docs/process/`, release records in `docs/releases/`, quickstarts in `docs/getting-started/`, and historical artifacts in `docs/archive/`.
+
+11. Publish workflow now runs `scripts/preflight-publish-check.js` before lint/typecheck/build to stop duplicate-version releases early (avoids npm E403 on already-published versions).
+12. Use `npm run publish:prepare` to auto-bump workspace versions and run duplicate-version preflight before publishing; this avoids manual per-package version tracking.

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -167,6 +167,22 @@ To avoid `E404 Scope not found` during workspace publishing:
 
 This allows forks and contributor tokens to publish without rewriting package manifests manually.
 
+### Duplicate Version Auto-Bump + Preflight Guard
+
+The publish workflow now runs:
+1. `node scripts/auto-bump-publish-versions.js`
+2. `node scripts/preflight-publish-check.js`
+
+This runs **before lint/typecheck/build**. The auto-bump script checks npm for every workspace package (`npm view <name>@<version> version`) and automatically increments patch versions across root + all workspaces until an unpublished version is found. The preflight script then verifies there are no duplicates left.
+
+This prevents late-stage `npm publish --workspaces` failures like:
+- `E403 Forbidden - You cannot publish over the previously published versions`
+
+Local commands:
+1. `npm run publish:auto-bump`
+2. `npm run publish:preflight`
+3. `npm run publish:prepare` (runs both in sequence)
+
 ## Automated CI/CD
 
 ### GitHub Actions Setup

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     "prepare": "npm run build",
     "version": "node scripts/update-version.js && git add VERSION.json",
     "publish:packages": "npm publish --workspaces",
-    "prerelease": "npm run build && npm run typecheck && npm run lint"
+    "prerelease": "npm run build && npm run typecheck && npm run lint",
+    "publish:preflight": "node scripts/preflight-publish-check.js",
+    "publish:auto-bump": "node scripts/auto-bump-publish-versions.js",
+    "publish:prepare": "npm run publish:auto-bump && npm run publish:preflight"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/scripts/auto-bump-publish-versions.js
+++ b/scripts/auto-bump-publish-versions.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = new Set(process.argv.slice(2));
+const isDryRun = args.has('--dry-run');
+const forceBump = args.has('--force-bump');
+const maxBumpsArg = [...args].find((arg) => arg.startsWith('--max-bumps='));
+const maxBumps = Number.parseInt(maxBumpsArg?.split('=')[1] ?? '20', 10);
+
+if (!Number.isInteger(maxBumps) || maxBumps < 0) {
+  console.error('Invalid --max-bumps value. Use a non-negative integer.');
+  process.exit(1);
+}
+
+const rootDir = process.cwd();
+const rootPkgPath = path.join(rootDir, 'package.json');
+const versionJsonPath = path.join(rootDir, 'VERSION.json');
+const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf8'));
+
+function collectWorkspacePackagePaths(pkg) {
+  const workspacePatterns = Array.isArray(pkg.workspaces) ? pkg.workspaces : [];
+  const packageFiles = [];
+
+  for (const pattern of workspacePatterns) {
+    if (pattern.endsWith('/*')) {
+      const dir = path.join(rootDir, pattern.slice(0, -2));
+      if (!fs.existsSync(dir)) continue;
+
+      for (const entry of fs.readdirSync(dir)) {
+        const pkgPath = path.join(dir, entry, 'package.json');
+        if (fs.existsSync(pkgPath)) {
+          packageFiles.push(pkgPath);
+        }
+      }
+    } else {
+      const pkgPath = path.join(rootDir, pattern, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        packageFiles.push(pkgPath);
+      }
+    }
+  }
+
+  return packageFiles;
+}
+
+const workspacePackagePaths = collectWorkspacePackagePaths(rootPkg);
+if (!workspacePackagePaths.length) {
+  console.error('No workspace package.json files found.');
+  process.exit(1);
+}
+
+const packageRecords = workspacePackagePaths.map((pkgPath) => {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  return { pkgPath, pkg };
+});
+
+function checkAlreadyPublished(records) {
+  const duplicates = [];
+
+  for (const record of records) {
+    const { name, version } = record.pkg;
+    if (!name || !version) continue;
+
+    const spec = `${name}@${version}`;
+    try {
+      execSync(`npm view ${JSON.stringify(spec)} version`, {
+        stdio: 'pipe',
+        encoding: 'utf8'
+      });
+      duplicates.push(spec);
+    } catch {
+      // Missing version is expected and means publish is possible.
+    }
+  }
+
+  return duplicates;
+}
+
+function bumpPatch(version) {
+  const [core] = version.split('-');
+  const [major, minor, patch] = core.split('.').map((v) => Number.parseInt(v, 10));
+  if (![major, minor, patch].every(Number.isInteger)) {
+    throw new Error(`Unsupported semver format: ${version}`);
+  }
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+function applyVersion(nextVersion) {
+  rootPkg.version = nextVersion;
+
+  const internalNames = new Set(packageRecords.map((record) => record.pkg.name).filter(Boolean));
+  for (const record of packageRecords) {
+    record.pkg.version = nextVersion;
+
+    for (const depField of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+      const deps = record.pkg[depField];
+      if (!deps || typeof deps !== 'object') continue;
+
+      for (const depName of Object.keys(deps)) {
+        if (depName === rootPkg.name || internalNames.has(depName)) {
+          deps[depName] = nextVersion;
+        }
+      }
+    }
+  }
+}
+
+let duplicateSpecs = forceBump ? ['forced-bump'] : checkAlreadyPublished(packageRecords);
+let bumps = 0;
+
+while (duplicateSpecs.length) {
+  if (bumps >= maxBumps) {
+    console.error(`Reached max bump attempts (${maxBumps}) while versions are still published:`);
+    for (const spec of duplicateSpecs) {
+      console.error(` - ${spec}`);
+    }
+    process.exit(1);
+  }
+
+  const currentVersion = rootPkg.version;
+  const nextVersion = bumpPatch(currentVersion);
+  applyVersion(nextVersion);
+  bumps += 1;
+
+  console.log(`Auto-bumped workspace versions: ${currentVersion} -> ${nextVersion}`);
+
+  duplicateSpecs = checkAlreadyPublished(packageRecords);
+}
+
+if (isDryRun) {
+  console.log(`Dry run complete. Final candidate version: ${rootPkg.version} (bumps applied: ${bumps}).`);
+  process.exit(0);
+}
+
+fs.writeFileSync(rootPkgPath, `${JSON.stringify(rootPkg, null, 2)}\n`);
+for (const record of packageRecords) {
+  fs.writeFileSync(record.pkgPath, `${JSON.stringify(record.pkg, null, 2)}\n`);
+}
+
+if (bumps > 0 && fs.existsSync(versionJsonPath)) {
+  const versionJson = JSON.parse(fs.readFileSync(versionJsonPath, 'utf8'));
+  const [major, minor, patch] = rootPkg.version.split('.').map((v) => Number.parseInt(v, 10));
+  versionJson.version = rootPkg.version;
+  versionJson.majorVersion = major;
+  versionJson.minorVersion = minor;
+  versionJson.patchVersion = patch;
+  versionJson.prerelease = null;
+  versionJson.releaseDate = new Date().toISOString().split('T')[0];
+
+  if (versionJson.metadata) {
+    versionJson.metadata.buildNumber = (versionJson.metadata.buildNumber || 1000) + bumps;
+  }
+
+  fs.writeFileSync(versionJsonPath, `${JSON.stringify(versionJson, null, 2)}\n`);
+}
+
+if (bumps === 0) {
+  console.log(`No auto-bump needed; version ${rootPkg.version} is publishable.`);
+} else {
+  console.log(`Auto-bump complete. Updated manifests to ${rootPkg.version}.`);
+}

--- a/scripts/preflight-publish-check.js
+++ b/scripts/preflight-publish-check.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const rootDir = process.cwd();
+const rootPkgPath = path.join(rootDir, 'package.json');
+const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf8'));
+const workspacePatterns = Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : [];
+
+const packageFiles = [];
+for (const pattern of workspacePatterns) {
+  if (pattern.endsWith('/*')) {
+    const dir = path.join(rootDir, pattern.slice(0, -2));
+    if (!fs.existsSync(dir)) continue;
+
+    for (const entry of fs.readdirSync(dir)) {
+      const pkgPath = path.join(dir, entry, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        packageFiles.push(pkgPath);
+      }
+    }
+  } else {
+    const pkgPath = path.join(rootDir, pattern, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      packageFiles.push(pkgPath);
+    }
+  }
+}
+
+if (!packageFiles.length) {
+  console.error('No workspace package.json files found for preflight publish check.');
+  process.exit(1);
+}
+
+const alreadyPublished = [];
+for (const pkgPath of packageFiles) {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  if (!pkg.name || !pkg.version) continue;
+
+  const spec = `${pkg.name}@${pkg.version}`;
+  try {
+    execSync(`npm view ${JSON.stringify(spec)} version`, {
+      stdio: 'pipe',
+      encoding: 'utf8'
+    });
+    alreadyPublished.push(spec);
+  } catch {
+    // npm view returns non-zero when the version does not exist, which is expected.
+  }
+}
+
+if (alreadyPublished.length) {
+  console.error('Preflight publish check failed. These versions already exist on npm:');
+  for (const spec of alreadyPublished) {
+    console.error(` - ${spec}`);
+  }
+  console.error('\nBump versions before publishing to avoid E403 publish failures.');
+  process.exit(1);
+}
+
+console.log(`Preflight publish check passed for ${packageFiles.length} workspace package(s).`);


### PR DESCRIPTION
### Motivation
- Prevent `npm publish --workspaces` failures caused by already-published workspace versions by detecting duplicates early and automating safe patch bumps.
- Reduce wasted CI compute by running duplicate-version detection/bump before lint/typecheck/build in the publish pipeline.
- Provide developer-facing scripts and docs to make publish preparation reproducible and scriptable.

### Description
- Added `scripts/auto-bump-publish-versions.js` to automatically patch-bump root and workspace package versions until an unpublished version is found and to update `VERSION.json` when applicable. 
- Added `scripts/preflight-publish-check.js` to fail fast if any workspace package version is already published on npm. 
- Updated `.github/workflows/publish.yml` to run the auto-bump and preflight scripts prior to lint/typecheck/build and before `npm publish --workspaces`. 
- Added npm scripts `publish:auto-bump`, `publish:preflight`, and `publish:prepare` to `package.json`, updated `prerelease`, and documented the flow in `docs/NPM_PUBLISHING.md`, `CHANGELOG.md`, and `CLAUDE.md`.

### Testing
- No automated test suite was added or executed as part of this PR; CI publish workflow will execute the preflight and build steps during runs of `.github/workflows/publish.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd0c7b1b883289aa743cd55d3b67a)