### PR TITLE
fix(ci): recover publish flow from merged workspace-version conflicts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: 20.x
           registry-url: https://registry.npmjs.org
 
+      - name: Prepare workspace publish versions
+        run: npm run publish:prepare
+
       - name: Install dependencies
         run: npm ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Changed
-- TBD for next release
+- Added `npm run publish:prepare` to automatically bump workspace package patch versions when a matching npm version already exists.
 
 ### Deprecated
 - TBD for next release
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,18 @@
 
 ### Documentation Drift Prevention
 - Keep GitHub Actions examples in `docs/NPM_PUBLISHING.md`, `fused-gaming-mcp-manifest.md`, `fused-gaming-mcp-prompts.md`, and `fused-gaming-mcp-execution.md` aligned with live workflows to avoid reintroducing deprecated `@v4` references.
+
+## Agent Notes (2026-04-13, Workspace Publish Merge-Conflict Recovery)
+
+### What Was Fixed
+- Added `scripts/prepare-publish-versions.cjs` to detect workspace package versions that are already published on npm and patch-bump them before release.
+- Script also rewrites internal workspace dependency ranges to keep package graph consistent after bumping.
+- Updated `.github/workflows/publish.yml` to run `npm run publish:prepare` before dependency install and publish steps.
+
+### Why This Prevents Repeat Failures
+- Merge-order conflicts across CI/version-bump PRs no longer depend on manual sequencing.
+- Publish jobs can recover automatically when a package version already exists upstream.
+
+### Follow-up for Next Agent
+1. Validate publish workflow on a tag in GitHub Actions with npm registry access.
+2. If any package requires a non-patch bump policy, add a strategy flag to `prepare-publish-versions.cjs`.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prepare": "npm run build",
     "version": "node scripts/update-version.js && git add VERSION.json",
     "publish:packages": "npm publish --workspaces",
-    "prerelease": "npm run build && npm run typecheck && npm run lint"
+    "prerelease": "npm run build && npm run typecheck && npm run lint",
+    "publish:prepare": "node scripts/prepare-publish-versions.cjs && npm install --package-lock-only --ignore-scripts"
   },
   "engines": {
     "node": ">=20.0.0",
@@ -65,4 +66,3 @@
     "docs/"
   ]
 }
-

--- a/scripts/prepare-publish-versions.cjs
+++ b/scripts/prepare-publish-versions.cjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+/**
+ * Ensure workspace package versions are publishable.
+ * - Checks npm for each workspace package@version.
+ * - If already published, bumps patch version.
+ * - Rewrites local workspace dependency ranges to bumped versions.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const defaultWorkspaceRoots = ['packages/core', 'packages/cli', 'packages/skills'];
+
+function findWorkspacePackageJsons() {
+  const files = [];
+
+  for (const root of defaultWorkspaceRoots) {
+    const absRoot = path.join(repoRoot, root);
+    if (!fs.existsSync(absRoot)) continue;
+
+    const entries = fs.readdirSync(absRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      const candidate = entry.isDirectory()
+        ? path.join(absRoot, entry.name, 'package.json')
+        : path.join(absRoot, 'package.json');
+
+      if (fs.existsSync(candidate) && candidate.endsWith('package.json')) {
+        files.push(candidate);
+      }
+    }
+
+    if (fs.existsSync(path.join(absRoot, 'package.json'))) {
+      files.push(path.join(absRoot, 'package.json'));
+    }
+  }
+
+  return [...new Set(files)];
+}
+
+function npmVersionExists(name, version) {
+  try {
+    const out = execSync(`npm view ${JSON.stringify(`${name}@${version}`)} version --json`, {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8'
+    }).trim();
+
+    if (!out) return false;
+    const parsed = JSON.parse(out);
+    return Boolean(parsed);
+  } catch (error) {
+    const stderr = String(error.stderr || error.message || '');
+    if (/E404|404/.test(stderr)) return false;
+
+    console.error(`❌ Failed to check npm for ${name}@${version}`);
+    console.error(stderr.trim());
+    process.exit(1);
+  }
+}
+
+function bumpPatch(version) {
+  const [core] = version.split('-');
+  const [major, minor, patch] = core.split('.').map((n) => parseInt(n, 10));
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+const packageFiles = findWorkspacePackageJsons();
+const packages = packageFiles.map((file) => {
+  const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return { file, name: json.name, version: json.version, json };
+});
+
+const changed = [];
+for (const pkg of packages) {
+  if (!pkg.name || !pkg.version) continue;
+  if (npmVersionExists(pkg.name, pkg.version)) {
+    const nextVersion = bumpPatch(pkg.version);
+    pkg.json.version = nextVersion;
+    changed.push({ name: pkg.name, from: pkg.version, to: nextVersion, file: pkg.file });
+    pkg.version = nextVersion;
+  }
+}
+
+const versionMap = new Map(packages.map((p) => [p.name, p.version]));
+for (const pkg of packages) {
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    const deps = pkg.json[field];
+    if (!deps) continue;
+
+    for (const depName of Object.keys(deps)) {
+      if (versionMap.has(depName)) {
+        deps[depName] = `^${versionMap.get(depName)}`;
+      }
+    }
+  }
+}
+
+for (const pkg of packages) {
+  fs.writeFileSync(pkg.file, `${JSON.stringify(pkg.json, null, 2)}\n`);
+}
+
+if (changed.length === 0) {
+  console.log('✅ All workspace package versions are publishable (no bump needed).');
+} else {
+  console.log('⚠️ Bumped workspace package versions already present on npm:');
+  for (const item of changed) {
+    console.log(` - ${item.name}: ${item.from} -> ${item.to}`);
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent publish failures caused by out-of-order merges that left workspace package versions already present on npm, which broke automated publish jobs and required manual intervention.
- Ensure the publish job can recover deterministically by either preparing versions or surfacing a clear registry/policy failure early.

### Description
- Add `scripts/prepare-publish-versions.cjs` which checks each workspace `name@version` on npm and patch-bumps the version when it already exists, then rewrites internal workspace dependency ranges to the bumped versions.
- Run the new preparation step before installing dependencies in the publish workflow by adding a `npm run publish:prepare` step in `.github/workflows/publish.yml`.
- Add a root npm script `publish:prepare` to run the script and synchronize the lockfile with `npm install --package-lock-only --ignore-scripts` in `package.json`.
- Update `CHANGELOG.md` (Unreleased) and `CLAUDE.md` with notes describing the recovery behavior and next-agent verification steps.

### Testing
- Ran `node --check scripts/prepare-publish-versions.cjs` which passed syntax validation successfully.
- Executed `npm run publish:prepare` locally which exercised the script but failed due to npm registry HTTP 403 in this environment, indicating a network/registry permission limitation rather than a code error.
- Recommend validating the full publish flow by running the publish workflow in GitHub Actions (tag push) with valid `NPM_TOKEN`/registry access to confirm auto-bumping behavior and lockfile synchronization; this is required to fully verify integration success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd72b08e0832888028a83bd498f4b)