### PR TITLE
fix(ci): sync lockfile after publish:prepare in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Prepare workspace publish versions
         run: npm run publish:prepare
 
+      - name: Sync lockfile for publish adjustments
+        run: npm install --package-lock-only --ignore-scripts
+
       - name: Install dependencies
         run: npm ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
+- Added an explicit lockfile sync step in `.github/workflows/publish.yml` immediately after `publish:prepare` so `npm ci` uses an updated lockfile after version auto-bumps.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,19 @@
 ### Follow-up for Next Agent
 1. Validate publish workflow on a tag in GitHub Actions with npm registry access.
 2. If any package requires a non-patch bump policy, add a strategy flag to `prepare-publish-versions.cjs`.
+
+## Agent Notes (2026-04-13, Publish Lockfile Sync + PR Check Visibility)
+
+### What Was Adjusted
+- Added a dedicated lockfile synchronization step to `.github/workflows/publish.yml`:
+  - `npm install --package-lock-only --ignore-scripts`
+  - Runs immediately after `npm run publish:prepare` and before `npm ci`.
+- This ensures auto-bumped workspace versions from `prepare-publish-versions.cjs` are reflected in `package-lock.json` before frozen install.
+
+### Why
+- `publish:prepare` mutates workspace `package.json` versions and internal ranges.
+- Without refreshing the lockfile first, `npm ci` can fail due to lock/package manifest mismatch.
+
+### GitHub Visibility Constraint Encountered
+- Public PR pages #38/#40/#41/#42/#43 are visible, but unauthenticated checks/deployments detail is partially unavailable in this environment (GitHub API returns HTTP 403; checks UI reports loading errors).
+- Next agent should validate real checks/deployments from an authenticated GitHub session or Actions UI.


### PR DESCRIPTION
### Motivation
- Prevent `npm ci` failures in the publish job caused by `scripts/prepare-publish-versions.cjs` auto-bumping workspace `package.json` versions without updating `package-lock.json`. 
- Make the tag-triggered publish sequence deterministic so merge-order/version-bump conflicts are auto-recoverable. 

### Description
- Add a lockfile synchronization step `npm install --package-lock-only --ignore-scripts` to `.github/workflows/publish.yml` immediately after `npm run publish:prepare` and before `npm ci`.
- Update `CHANGELOG.md` Unreleased > Fixed to document the new lockfile sync behavior. 
- Update `CLAUDE.md` to record the change, rationale, and a handoff note about limited unauthenticated GitHub checks visibility. 
- Commit the changes on branch `work` and create a PR payload that describes deliverables and success metrics for next-agent validation. 

### Testing
- Verified repository edits and staging with `git status --short` and reviewed the updated files (`.github/workflows/publish.yml`, `CHANGELOG.md`, `CLAUDE.md`).
- Committed the changes successfully with `git commit` and created the PR payload (PR created for the fix). 
- Manual workflow review confirmed the publish step order is now `publish:prepare` -> lockfile sync -> `npm ci` -> build -> publish. 
- Attempted to validate live GitHub checks for related PRs but GitHub API returned HTTP 403 in this environment, so CI/publish runs were not executable here and require an authenticated Actions UI to confirm end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcef212d7483289bca9821e2d5de8c)