### PR TITLE
docs: add blocker-oriented handoff and next-step priorities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,20 @@
 ### GitHub Visibility Constraint Encountered
 - Public PR pages #38/#40/#41/#42/#43 are visible, but unauthenticated checks/deployments detail is partially unavailable in this environment (GitHub API returns HTTP 403; checks UI reports loading errors).
 - Next agent should validate real checks/deployments from an authenticated GitHub session or Actions UI.
+
+## Agent Notes (2026-04-13, Orientation + Priority Refresh)
+
+### Blockers Confirmed
+- No dedicated roadmap file was found from local repo discovery (`roadmap`/`ROADMAP`/`plan` filename patterns did not return a project roadmap document).
+- GitHub PR checks/deployments for PRs `#38`, `#40`, `#41`, `#42`, `#43` cannot be fully validated in this environment due unauthenticated/API access limits (HTTP 403 responses).
+
+### Current Progress Snapshot
+- Publish control point remains centralized in:
+  - `scripts/prepare-publish-versions.cjs`
+  - `.github/workflows/publish.yml`
+- Lockfile synchronization mitigation is already landed in `publish.yml` and should be treated as baseline behavior for tag publish verification.
+
+### Immediate Next 3 Steps (for next agent)
+1. Validate checks/deployments for PRs `#38/#40/#41/#42/#43` from an authenticated GitHub Actions session.
+2. Push a test tag (`v*` or `skill-*`) and confirm publish workflow completes end-to-end with the current `publish:prepare -> lockfile sync -> npm ci` sequence.
+3. If publish errors persist, iterate first in `scripts/prepare-publish-versions.cjs` and `.github/workflows/publish.yml`, then re-run tag publish.

--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -325,3 +325,19 @@ This session successfully delivered a production-ready MCP ecosystem with:
 **Session completed on:** April 1, 2026  
 **Next session:** Can start with new feature branch anytime  
 **Status:** Ready for launch ✨
+
+---
+
+## Continuation Handoff (2026-04-13)
+
+### Blockers
+- No repository roadmap file found via local filename discovery (`roadmap`/`ROADMAP`/`plan` patterns).
+- Live checks/deployments for PRs #38/#40/#41/#42/#43 are not fully observable from this environment due unauthenticated GitHub API/access limits (HTTP 403).
+
+### Current Step Completed
+- Kept CI publish troubleshooting anchored to the primary control point and confirmed lockfile synchronization is already integrated in `.github/workflows/publish.yml` immediately after `publish:prepare`.
+
+### Immediate Next 3 Steps
+1. Validate checks/deployments for PRs #38/#40/#41/#42/#43 in an authenticated GitHub Actions session.
+2. Push a test tag (`v*` or `skill-*`) and confirm end-to-end publish success with the current lockfile sync sequence.
+3. If publish failures persist, iterate first in `scripts/prepare-publish-versions.cjs` and `.github/workflows/publish.yml`.


### PR DESCRIPTION
### Motivation
- Capture confirmed blockers (missing in-repo roadmap and unauthenticated GitHub PR visibility) and preserve next-step priorities so the next agent can continue without re-discovery.

### Description
- Added an "Agent Notes (2026-04-13, Orientation + Priority Refresh)" section to `CLAUDE.md` and a "Continuation Handoff (2026-04-13)" section to `SESSION_SUMMARY.md` that document the blockers, the current publish-control-point snapshot (`scripts/prepare-publish-versions.cjs` and `.github/workflows/publish.yml`), and the immediate next 3 actionable steps for the next agent.

### Testing
- Verified changes and repository state with `git status --short`, viewed the updated files via `nl` on `CLAUDE.md` and `SESSION_SUMMARY.md`, and confirmed the absence of a local roadmap with `rg` (all succeeded), and attempted `curl` checks against the GitHub PR API for #38/#40/#41/#42/#43 which returned HTTP 403 due to unauthenticated environment restrictions (visibility could not be validated here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf208b6e883288e7eaaba67afbf04)