### PR TITLE
ci: enforce lockfile freshness for Node 20 dependency stability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify package-lock is up to date
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          git diff --exit-code package-lock.json
+
       - name: Lint
         run: npm run lint --if-present
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify package-lock is up to date
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          git diff --exit-code package-lock.json
+
       - name: Lint
         run: npm run lint --if-present
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Multi-account session tracking**: Removed an unused accumulator variable in session aggregation to resolve static analysis/code quality findings (multi-account-session-tracking-skill).
 - **Multi-account session tracking**: Replaced `any` typing in daily review/session aggregation models with explicit typed records to remove lint warnings that can break stricter CI gates (multi-account-session-tracking-skill).
+- **CI/CD**: Added lockfile verification in `test` and `publish` workflows to fail fast when package dependencies change without corresponding `package-lock.json` updates.
 
 ### Security
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 
 ## Execution Tips
 - CI `npm ci` can fail with EUSAGE if a new workspace package is added but root `package-lock.json` is not regenerated. Run `npm install` at repo root and commit the lockfile update.
+- CI now enforces lockfile freshness in `test.yml` and `publish.yml` via `npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json`; dependency-only edits must include lockfile changes in the same commit.
 - Run quality checks with:
   - `npm run lint`
   - `npm run typecheck`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,7 @@ This release represents the complete production deployment of the Fused Gaming M
 - Generated `package-lock.json` for reproducible builds
 - Converted pnpm workspace:* protocol to npm-compatible format
 - All 11 workspace packages verified and resolved
-- Node.js requirement: >=18.0.0
+- Node.js requirement: >=20.0.0
 - npm requirement: >=8.0.0
 
 ### ✅ Build & Verification
@@ -77,7 +77,7 @@ eslint: ^10.1.0
 ## Deployment Instructions
 
 ### Prerequisites
-- Node.js 18.0.0 or higher
+- Node.js 20.0.0 or higher
 - npm 8.0.0 or higher
 
 ### Installation


### PR DESCRIPTION
### Motivation
- Recent pipeline failures on the Node 20 matrix and missing package dependencies were caused by package manifest changes not accompanied by `package-lock.json` updates, so CI must catch lockfile drift early. 
- The repository runtime baseline and handoff guidance needed alignment to Node 20 to reflect current `package.json` engines and reduce confusion during triage.

### Description
- Added a lockfile freshness gate to `test` and `publish` GitHub Actions by running `npm install --package-lock-only --ignore-scripts` and `git diff --exit-code package-lock.json` immediately after dependency installation in `.github/workflows/test.yml` and `.github/workflows/publish.yml`.
- Updated `CHANGELOG.md` to record the new CI guardrail and updated `RELEASE_NOTES.md` and other docs to set Node baseline references to `>=20.0.0`.
- Updated `CLAUDE.md` to document the new lockfile enforcement and remind agents to regenerate and commit `package-lock.json` when changing dependencies.
- Committed changes on branch `work` with message `ci: enforce lockfile freshness and document node 20 baseline` and prepared PR titled `ci: enforce lockfile freshness for Node 20 dependency stability`.

### Testing
- Ran `npm ci` and `npm install` at repository root, both completed successfully and built all workspace packages.
- Ran `npm run lint`, `npm run typecheck`, and `npm test` across workspaces and observed success (no lint/type errors and test placeholders executed).
- Executed the lockfile freshness verification locally via `npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json` and confirmed no diffs (check passes).
- CI workflows retain the Node matrix (`20.x`, `24.x`) so the added checks will fail fast on lockfile drift during automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb5e7dbec832880ad5edf84a370b0)