### PR TITLE
docs(release): prepare PR #51 merge readiness and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `docs/process/PR_51_MERGE_CHECKLIST.md` with explicit PR #51 deliverables, success metrics, blockers, execution order, and next-agent handoff directives.
 - Added `scripts/auto-bump-publish-versions.js` to automatically patch-bump root/workspace package versions until npm reports they are publishable.
 - Added `scripts/preflight-publish-check.js` and wired it into publish CI to fail fast when any workspace package version is already published on npm.
 - Added a documentation index (`docs/README.md`) and reorganized root-level docs into categorized directories (`docs/getting-started`, `docs/process`, `docs/releases`, `docs/archive`).
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added `npm run publish:prepare` to automatically bump workspace package patch versions when a matching npm version already exists.
+- Updated roadmap and README planning sections to include milestone/issue tracking for the daily-review merge and next-wave skill/tool rollout.
+- Updated `CLAUDE.md` with PR #51 orientation notes to reduce repeated PR-status/debug loops for the next agent.
 
 ### Deprecated
 - TBD for next release
@@ -31,6 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - TBD for next release
+
+## [1.0.1] - 2026-04-16
+
+### Added
+- PR #51 merge-readiness checklist and handoff doc with blockers, active steps, and immediate next three tasks.
+- Milestone and issue-oriented roadmap entries for planned tools/skills (`daily-review`, `project-status-tool`, `project-manager`, and deployment/status automation).
+
+### Changed
+- Bumped repository version metadata to `1.0.1` for daily-review merge readiness documentation and planning sync.
+- Refreshed root README roadmap snapshot, priorities, and blockers to align with the PR #51 review window.
 
 ## [1.0.0] - 2026-04-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,19 @@
 ### Follow-up for Next Agent
 1. Validate publish workflow on a tag in GitHub Actions with npm registry access.
 2. If any package requires a non-patch bump policy, add a strategy flag to `prepare-publish-versions.cjs`.
+
+## Agent Notes (2026-04-16, PR #51 Merge Readiness)
+
+### Orientation Updates
+- PR #51 merge-readiness documentation was consolidated into `docs/process/PR_51_MERGE_CHECKLIST.md`.
+- Version metadata was bumped to `1.0.1` to mark the daily-review merge-prep window.
+- Roadmap now includes explicit milestone/issue buckets for planned tools/skills and release observability tasks.
+
+### Environment Constraints Reconfirmed
+- `gh` CLI is not available in this runtime.
+- Git remotes/API credentials are not configured locally, so live PR comments/check-runs/deployment outcomes cannot be queried from terminal.
+
+### Next Agent Priority Sequence
+1. Verify PR #51 and related recent PR workflow/deployment states in GitHub UI.
+2. If any checks fail, fix those errors first and rerun workflows before additional feature work.
+3. Continue next-wave skill implementation (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`) after CI/deployment stability is confirmed.

--- a/README.md
+++ b/README.md
@@ -181,15 +181,19 @@ npm run dev         # Start dev server
 - 🔄 Promote release checklist automation from docs into CI validation gates
 - 🔄 Expand deployment verification for npm + GitHub release parity
 - 🔄 Add richer release announcement templates for community launch posts
+- 🔄 Merge and publish `daily-review` with release-quality docs and examples (PR #51 target)
+- 🔄 Implement tool logic + tests for `project-status-tool` and `project-manager`
+- 🔄 Formalize planned-tool milestones into trackable issue groups for weekly triage
 
 ### Current blockers to watch
 - GitHub PR/status triage currently depends on repository API/CLI availability in the execution environment.
 - Scope configuration (`NPM_SCOPE`) must be set in GitHub Actions variables for organization-owned publishing.
+- Without GitHub CLI/API credentials in the runtime, PR #51 check-run and deployment state must be confirmed directly in GitHub UI.
 
 ### Top 3 priorities now
-1. Ship missing high-impact skills (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`).
-2. Add automated docs/package consistency checks for published scope metadata.
-3. Track deployment/test status per release PR in a single release checklist.
+1. Complete PR #51 merge-readiness checks (docs/version/changelog + status triage evidence).
+2. Ship missing high-impact skills (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`) with executable tests.
+3. Add automated docs/package consistency checks for published scope metadata and release checklists.
 
 ---
 
@@ -243,7 +247,7 @@ Apache 2.0 — See [LICENSE](./LICENSE) for details
 
 ---
 
-[![Version 1.0.0](https://img.shields.io/badge/version-1.0.0-blue)](./VERSION.json)
-[![Released April 2, 2026](https://img.shields.io/badge/released-april%202%2C%202026-brightgreen)](./docs/releases/RELEASE_NOTES.md)
+[![Version 1.0.1](https://img.shields.io/badge/version-1.0.1-blue)](./VERSION.json)
+[![Released April 16, 2026](https://img.shields.io/badge/released-april%2016%2C%202026-brightgreen)](./docs/releases/RELEASE_NOTES.md)
 [![Status: Stable](https://img.shields.io/badge/status-stable-brightgreen)](./CHANGELOG.md)
 [![Maintained](https://img.shields.io/badge/maintained%3F-yes-brightgreen)](https://github.com/Fused-Gaming/Fused-Gaming-Skill-MCP)

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,16 +1,16 @@
 {
-  "version": "1.0.0",
-  "releaseDate": "2026-04-02",
+  "version": "1.0.1",
+  "releaseDate": "2026-04-16",
   "status": "stable",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 0,
+  "patchVersion": 1,
   "prerelease": null,
   "metadata": {
     "nodeMinimum": "18.0.0",
     "npmMinimum": "8.0.0",
     "typescriptVersion": "5.3.2",
-    "buildNumber": 1001
+    "buildNumber": 1002
   },
   "packageInfo": {
     "name": "@fused-gaming/mcp",

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@
 ## Contribution & Process
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md)
 - [`process/BRANCHING_STRATEGY.md`](./process/BRANCHING_STRATEGY.md)
+- [`process/PR_51_MERGE_CHECKLIST.md`](./process/PR_51_MERGE_CHECKLIST.md)
 
 ## Archived Historical Material
 - [`archive/session-artifacts/`](./archive/session-artifacts/)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -124,17 +124,51 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 2. Newly scaffolded skills still need full tool logic, tests, and release tags before npm publication.
 3. Planned backlog is not yet mapped into implementation-ready milestones (owners, dates, dependencies).
 
+## PR #51 Merge Readiness (Daily Review + Follow-on Skills)
+
+### Deliverables and success metrics
+1. **Documentation sync complete**: README, roadmap, changelog, and release planning docs are aligned.
+2. **Versioning complete**: repository metadata bumped for merge-review traceability.
+3. **Execution clarity**: blockers/current steps/next-three-steps are explicitly documented for handoff.
+4. **Milestone + issue mapping**: planned tools/skills are grouped into trackable delivery streams.
+
+### Recent PR status notes (environment constraints)
+- Local git history confirms related merged PRs (`#44`, `#46`, `#45`, `#42`, `#39`) touching CI, docs, and scaffolding.
+- Live comments/check-runs/deployment states for PR #51 and recent PRs **cannot be queried in this runtime** because GitHub CLI (`gh`) and remote/API credentials are unavailable.
+- Action required: confirm check suites and deployment conclusions in GitHub UI before merging PR #51.
+
 ## Current Steps
 
 1. Keep release-facing docs synchronized with actual `@h4shed` package publication.
-2. Complete implementation for newly scaffolded skills.
-3. Keep release workflow docs synchronized with CI workflows.
+2. Finalize PR #51 merge-readiness docs/version/changelog updates.
+3. Complete implementation for newly scaffolded skills.
+4. Keep release workflow docs synchronized with CI workflows.
 
 ## Immediate Next 3 Steps
 
-1. Implement production logic + tests for `mermaid-terminal`, `ux-journeymapper`, `svg-generator`.
-2. Create release tags and publish plan for the full scaffolded skill batch.
+1. Verify PR #51 checks/deployments in GitHub UI and resolve any failing workflows before merge.
+2. Implement production logic + tests for `mermaid-terminal`, `ux-journeymapper`, `svg-generator`.
 3. Add CI validation to ensure docs package names stay aligned with published scope metadata.
+
+---
+
+## Milestones and Issue Buckets (Planned Tools + Skills)
+
+### Milestone M1 — PR #51 Daily Review Merge Stabilization (target: immediate)
+- **Issue A:** Validate and document PR #51 check-run and deployment outcomes.
+- **Issue B:** Keep changelog/version/docs synchronized in same merge window.
+- **Issue C:** Capture blocker/handoff notes for next agent to avoid duplicate triage.
+
+### Milestone M2 — Next-Wave Skill Completion (target: next release cycle)
+- **Issue A:** `skill-mermaid-terminal` implementation + tests.
+- **Issue B:** `skill-ux-journeymapper` implementation + tests.
+- **Issue C:** `skill-svg-generator` implementation + tests.
+- **Issue D:** `skill-project-manager` and `skill-project-status-tool` MVP command sets.
+
+### Milestone M3 — Planned Tooling and Release Observability (target: subsequent cycle)
+- **Issue A:** Unified PR release checklist with test/deploy evidence links.
+- **Issue B:** CI guardrails to detect docs/package/version drift.
+- **Issue C:** Automation for milestone issue template generation from roadmap backlog.
 
 ---
 

--- a/docs/process/PR_51_MERGE_CHECKLIST.md
+++ b/docs/process/PR_51_MERGE_CHECKLIST.md
@@ -1,0 +1,50 @@
+# PR #51 Merge Checklist and Agent Orientation
+
+## Scope
+Prepare merge-ready documentation and versioning for PR #51 (daily review integration + planned follow-on skills/tools alignment).
+
+## Deliverables
+1. Update `README.md` roadmap snapshot and priority list.
+2. Update `docs/ROADMAP.md` blockers, current steps, and immediate next three steps.
+3. Add/refresh milestone + issue buckets for planned tools and skills.
+4. Bump repository version metadata for merge-window traceability.
+5. Update `CHANGELOG.md` for unreleased and versioned notes.
+6. Add agent handoff context to `CLAUDE.md`.
+
+## Success Metrics
+- Documentation sections referenced above are internally consistent.
+- Version values match across `VERSION.json`, `package.json`, and README badge.
+- A clear blocker list exists and includes execution-environment constraints.
+- Immediate next three steps are explicit and actionable.
+- Milestone and issue buckets map to the planned tools/skills in roadmap.
+
+## Blockers
+1. GitHub CLI (`gh`) is not installed in this environment.
+2. No git remotes/API credentials are configured; live PR comments and check-runs cannot be queried from terminal.
+3. Deployment/test status for recent PRs must be verified in GitHub UI.
+
+## Current Steps
+1. Keep docs/version/changelog in sync for PR #51 review.
+2. Validate PR check-runs/deployments in GitHub UI before merge.
+3. Resolve workflow errors first, then resume feature work.
+4. Continue implementation/testing of scaffolded skills after merge readiness is complete.
+
+## Immediate Next 3 Steps
+1. Open PR #51 in GitHub and confirm all checks + deployments are green.
+2. If any workflow fails, patch branch and rerun until green.
+3. Start implementation/test pass for `mermaid-terminal`, `ux-journeymapper`, and `svg-generator`.
+
+## Recent PRs Related to Current Branch (Local-Git Evidence)
+- `#44` fix(ci): recover publish flow from merged workspace-version conflicts.
+- `#46` docs: add blocker-oriented handoff and next-step priorities.
+- `#45` fix(ci): sync lockfile after publish:prepare in publish workflow.
+- `#42` feat(ci): automate workspace version bumping before publish.
+- `#39` merge: migrate deprecated Node.js GitHub Actions references.
+
+> Note: live check/deploy state for the PRs above must be confirmed in GitHub UI due to local environment limitations.
+
+## Agent Directives for Continuation
+- Prioritize workflow/deployment failures before new feature implementation.
+- Keep roadmap milestone/issue mapping updated whenever planned tools/skills change.
+- On successful merges, update changelog, version metadata, README, roadmap, and CLAUDE notes in the same PR.
+- Do not commit secrets or files containing sensitive tokens.

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -1,4 +1,22 @@
-# Release Notes - Production Deployment 2026-04-02
+# Release Notes
+
+## 1.0.1 - 2026-04-16 (PR #51 Merge-Readiness Update)
+
+### Overview
+This maintenance release prepares the repository for PR #51 merge approval by synchronizing version metadata and release-planning documentation.
+
+### Included in this update
+- PR #51 checklist and agent-orientation handoff document.
+- Updated roadmap milestones/issues for planned skills and tools.
+- Updated README roadmap snapshot and priority ordering.
+- Updated changelog and version metadata consistency (`VERSION.json`, `package.json`, README badge).
+
+### Known limitations
+- Live PR comment/check/deployment states still require GitHub UI verification when CLI/API access is unavailable in runtime.
+
+---
+
+## 1.0.0 - 2026-04-02 (Production Deployment)
 
 ## Overview
 This release represents the complete production deployment of the Fused Gaming MCP with comprehensive dependency updates, security hardening, and build verification.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fused-gaming/mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Modular MCP server with scalable Claude skills for Fused Gaming and VLN Security",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Motivation
- Prepare repository for merging PR #51 (daily-review integration) by synchronizing documentation, version metadata, and milestone/issue planning so reviewers and follow-up agents have a clear orientation and handoff.
- Capture known environment constraints and blockers (missing `gh` CLI and no configured git remotes/API credentials) to avoid repeated PR-status triage loops.

### Description
- Added `docs/process/PR_51_MERGE_CHECKLIST.md` containing deliverables, success metrics, blockers, current steps, immediate next-three-steps, recent PR context, and agent directives for handoff.
- Updated documentation and planning artifacts including `README.md`, `docs/ROADMAP.md`, `docs/README.md`, `CHANGELOG.md`, and `docs/releases/RELEASE_NOTES.md` to include PR #51 readiness, milestone/issue buckets for planned skills/tools, and adjusted priority ordering.
- Bumped repository version metadata from `1.0.0` to `1.0.1` in `VERSION.json` and `package.json` and updated badges in `README.md` to reflect the revision for merge-window traceability.
- Added orientation notes for the next agent in `CLAUDE.md` and updated the docs index to surface the new checklist file.

### Testing
- Ran `npm run lint` and the linting completed successfully (no blocking errors).
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking completed successfully (no type errors).
- Local verification noted that live PR check-run and deployment states cannot be queried in this environment because the `gh` CLI and remote/API credentials are unavailable, and therefore live CI status must be confirmed in the GitHub UI before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0aaf8c7b48328b9907386ad240d07)