### PR TITLE
fix(ci): resolve Node 24 test lane failure after mermaid terminal merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Resolved Node `24.x` CI workspace discovery failure (`EDUPLICATEWORKSPACE`) by assigning the legacy Mermaid package a unique workspace name (`@fused-gaming/skill-mermaid-terminal-legacy`) after the production `mermaid-terminal` merge.
 - Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.
 - Regenerated `package-lock.json` to include newly scaffolded workspace packages so `npm ci` no longer fails after development→main merges.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,15 @@
 1. Verify PR #51 and related recent PR workflow/deployment states in GitHub UI.
 2. If any checks fail, fix those errors first and rerun workflows before additional feature work.
 3. Continue next-wave skill implementation (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`) after CI/deployment stability is confirmed.
+
+## Agent Notes (2026-04-16, Node 24 test(24.x) workspace failure)
+
+### Root Cause
+- CI/test lane failed quickly with `EDUPLICATEWORKSPACE` because both `packages/skills/mermaid-terminal` and `packages/skills/mermaid-terminal-skill` declared the same package name `@fused-gaming/skill-mermaid-terminal`.
+
+### Fix Applied
+- Renamed the legacy workspace package to `@fused-gaming/skill-mermaid-terminal-legacy` to remove workspace-name collision while preserving old code for reference.
+
+### Guardrail for Next Agent
+1. Before merging scaffolded/legacy skill folders, verify **unique workspace package names** across `packages/skills/*/package.json`.
+2. If retaining a legacy directory, suffix with `-legacy` to avoid npm workspace discovery conflicts.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,6 +123,7 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 1. GitHub CLI/API visibility is required to inspect live PR comments/check-runs from this environment.
 2. Newly scaffolded skills still need full tool logic, tests, and release tags before npm publication.
 3. Planned backlog is not yet mapped into implementation-ready milestones (owners, dates, dependencies).
+4. **Resolved (2026-04-16):** Node `24.x` `test` workflow duplicate workspace failure caused by two Mermaid workspaces sharing the same package name.
 
 ## PR #51 Merge Readiness (Daily Review + Follow-on Skills)
 
@@ -141,7 +142,7 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 
 1. Keep release-facing docs synchronized with actual `@h4shed` package publication.
 2. Finalize PR #51 merge-readiness docs/version/changelog updates.
-3. Complete implementation for newly scaffolded skills.
+3. Complete implementation for newly scaffolded skills (after workspace collision fix validation).
 4. Keep release workflow docs synchronized with CI workflows.
 
 ## Immediate Next 3 Steps

--- a/packages/skills/mermaid-terminal-skill/README.md
+++ b/packages/skills/mermaid-terminal-skill/README.md
@@ -1,4 +1,4 @@
-# Mermaid Terminal Skill
+# Mermaid Terminal Skill (Legacy Workspace)
 
 Visualization engine for generating Mermaid diagrams in Fused Gaming MCP.
 
@@ -29,7 +29,7 @@ npm run build
 ### Generate Flowchart
 
 ```typescript
-import { generateFlowchart } from '@fused-gaming/skill-mermaid-terminal';
+import { generateFlowchart } from '@fused-gaming/skill-mermaid-terminal-legacy';
 
 const flowchart = generateFlowchart('Development Process', [
   { id: 'start', text: 'Start' },

--- a/packages/skills/mermaid-terminal-skill/package.json
+++ b/packages/skills/mermaid-terminal-skill/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fused-gaming/skill-mermaid-terminal",
+  "name": "@fused-gaming/skill-mermaid-terminal-legacy",
   "version": "1.0.0",
   "description": "Visualization engine for generating Mermaid diagrams from code analysis and documentation",
   "type": "module",


### PR DESCRIPTION
### Motivation
- The Node `24.x` CI `test` lane was failing with `EDUPLICATEWORKSPACE` because two workspace packages declared the same name, blocking the merge and downstream test/build steps. 
- The intent is to remove the workspace-name collision while preserving the legacy code for reference and to add guardrails to prevent recurrence.

### Description
- Renamed the legacy workspace package in `packages/skills/mermaid-terminal-skill/package.json` from `@fused-gaming/skill-mermaid-terminal` to `@fused-gaming/skill-mermaid-terminal-legacy` to eliminate the duplicate workspace name. 
- Updated the legacy README import example to use `@fused-gaming/skill-mermaid-terminal-legacy`. 
- Documented the root cause and fix in `CHANGELOG.md`, added guardrails and handoff notes in `CLAUDE.md`, and recorded the resolved blocker in `docs/ROADMAP.md`.
- No runtime changes to the production `mermaid-terminal` package; the legacy workspace remains available for reference.

### Testing
- Re-ran the workspace test suite with `npm test`, which completed successfully after the fix (previous run failed with `EDUPLICATEWORKSPACE`).
- Built all workspaces with `npm run build`, which completed successfully. 
- Type-checked the repository with `npm run typecheck` (`tsc --noEmit`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c5f8b37c83289571746c13cdac06)