### PR TITLE
fix(ci): resolve Node version workflow errors and align v1.0.3 docs

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,9 +14,14 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 24.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added scaffold packages for upcoming skills: mermaid-terminal, ux-journeymapper, svg-generator, project-manager, project-status-tool, daily-review, multi-account-session-tracking, and linkedin-master-journalist.
 
 ### Changed
+- Updated `.github/workflows/test.yml` Node matrix from `20.x`/`24.x` to active LTS lanes `20.x`/`22.x` to resolve Actions Node-version failures in CI testing.
+- Updated `.github/workflows/github-release.yml` to `actions/checkout@v5` and added an explicit `actions/setup-node@v5` (`22.x`) runtime step for consistent release-job Node behavior.
 - Added `npm run publish:prepare` to automatically bump workspace package patch versions when a matching npm version already exists.
 - Updated README and package publish file list to reflect the new documentation paths.
 - Updated `publish.yml` to publish npm workspaces on every push to `main` (including merges), while retaining tag-triggered releases and adding manual `workflow_dispatch` support.
@@ -24,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded README release/roadmap documentation to include existing status, planned follow-ups, and operational blockers.
 - Raised release metadata and docs minimum Node.js requirement references from `18.0.0` to `20.0.0` to align with workspace engines and active CI lanes.
 - Standardized workspace package README files to follow npm package documentation conventions (installation, usage/tooling context, development, and license sections).
-- Advanced release metadata from `1.0.1` to `1.0.2` for the current patch iteration.
+- Advanced release metadata from `1.0.2` to `1.0.3` for the current patch iteration.
 
 ### Deprecated
 - TBD for next release
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Aligned workflow runtime expectations and release docs around Node.js LTS lanes (`20.x`, `22.x`) to prevent test matrix Node-version mismatches.
 - Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
 - Added an explicit lockfile sync step in `.github/workflows/publish.yml` immediately after `publish:prepare` so `npm ci` uses an updated lockfile after version auto-bumps.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,15 @@
 ### Validation Notes
 1. Workspace tests still execute (`npm run test --workspaces --if-present`), but are mostly placeholder scripts.
 2. Lockfile/dependency sync remains blocked in this environment by npm registry HTTP 403 on `mermaid` (`npm install --package-lock-only --ignore-scripts`).
+
+
+## Agent Notes (2026-04-16, Node Workflow Test Lane Stabilization)
+
+### What Was Updated
+- Test workflow matrix was moved from Node `20.x` + `24.x` to `20.x` + `22.x` to keep CI on current active LTS lanes.
+- GitHub release workflow now uses `actions/checkout@v5` and includes explicit `actions/setup-node@v5` (`22.x`).
+- Release metadata/docs were bumped to `v1.0.3` and aligned with the workflow/runtime changes.
+
+### Remaining Blockers
+1. GitHub PR checks/deployment status still require authenticated API/UI access from outside this execution environment.
+2. Full dependency reinstall/lock refresh can still fail here when npm registry access returns HTTP 403 for transitive packages.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ npm run dev         # Start dev server
 
 ## 🗺️ Roadmap Snapshot (Existing + Planned)
 
-### Existing (v1.0.2)
+### Existing (v1.0.3)
 - ✅ 11 published `@h4shed/*` packages (core + CLI + 9 skills)
 - ✅ npm workspace publishing pipeline active on `main` and tags
 - ✅ Security baseline hardened (0 known vulnerabilities at last audit)
@@ -190,6 +190,7 @@ npm run dev         # Start dev server
 1. Ship missing high-impact skills (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`).
 2. Add automated docs/package consistency checks for published scope metadata.
 3. Track deployment/test status per release PR in a single release checklist.
+4. Keep Actions test matrix pinned to active LTS lanes (20.x, 22.x) to avoid Node-version runtime drift.
 
 ---
 
@@ -243,7 +244,7 @@ Apache 2.0 — See [LICENSE](./LICENSE) for details
 
 ---
 
-[![Version 1.0.2](https://img.shields.io/badge/version-1.0.2-blue)](./VERSION.json)
+[![Version 1.0.3](https://img.shields.io/badge/version-1.0.3-blue)](./VERSION.json)
 [![Released April 16, 2026](https://img.shields.io/badge/released-april%2016%2C%202026-brightgreen)](./docs/releases/RELEASE_NOTES.md)
 [![Status: Stable](https://img.shields.io/badge/status-stable-brightgreen)](./CHANGELOG.md)
 [![Maintained](https://img.shields.io/badge/maintained%3F-yes-brightgreen)](https://github.com/Fused-Gaming/Fused-Gaming-Skill-MCP)

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,16 +1,16 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "releaseDate": "2026-04-16",
   "status": "stable",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 2,
+  "patchVersion": 3,
   "prerelease": null,
   "metadata": {
     "nodeMinimum": "20.0.0",
     "npmMinimum": "8.0.0",
     "typescriptVersion": "5.3.2",
-    "buildNumber": 1003
+    "buildNumber": 1004
   },
   "packageInfo": {
     "name": "@fused-gaming/mcp",

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -225,7 +225,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -275,7 +275,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/docs/RELEASE_COMMUNICATION.md
+++ b/docs/RELEASE_COMMUNICATION.md
@@ -1,4 +1,4 @@
-# Release Communication Guide (v1.0.2)
+# Release Communication Guide (v1.0.3)
 
 This document captures a ready-to-use launch summary and recommendation set for announcing the first stable release.
 
@@ -7,7 +7,7 @@ This document captures a ready-to-use launch summary and recommendation set for 
 Use this in terminal or release-call notes:
 
 ```text
-Fused Gaming MCP v1.0.2 release prep summary
+Fused Gaming MCP v1.0.3 release prep summary
 - Existing: 9 production-ready skills (+ core + CLI) published on npm under @h4shed.
 - Updated: Release automation split into dedicated workflows:
   * npm publish: .github/workflows/publish.yml
@@ -19,7 +19,7 @@ Fused Gaming MCP v1.0.2 release prep summary
 ## LinkedIn Post (Recommended Draft)
 
 ```text
-🚀 We just shipped Fused Gaming MCP v1.0.2!
+🚀 We just shipped Fused Gaming MCP v1.0.3!
 
 After a full production hardening cycle, we launched our modular Model Context Protocol stack with 9 ready-to-use skills for design, dev, and creative automation.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,14 +127,15 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 ## Current Steps
 
 1. Keep release-facing docs synchronized with actual `@h4shed` package publication.
-2. Complete implementation for newly scaffolded skills.
-3. Keep release workflow docs synchronized with CI workflows.
+2. Keep CI test/runtime lanes aligned to active Node LTS versions (20.x/22.x) across all workflows.
+3. Complete implementation for newly scaffolded skills.
+4. Keep release workflow docs synchronized with CI workflows.
 
 ## Immediate Next 3 Steps
 
-1. Implement production logic + tests for `mermaid-terminal`, `ux-journeymapper`, `svg-generator`.
-2. Create release tags and publish plan for the full scaffolded skill batch.
-3. Add CI validation to ensure docs package names stay aligned with published scope metadata.
+1. Validate GitHub Actions `Test` matrix (`20.x`, `22.x`) and release workflow after Node lane adjustments.
+2. Implement production logic + tests for `mermaid-terminal`, `ux-journeymapper`, `svg-generator`.
+3. Add CI validation to ensure docs package names and Node runtime references stay aligned with workflows.
 
 ---
 

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+# Release Notes - Node Workflow Stabilization 2026-04-16
+
+## Overview
+This patch release (`v1.0.3`) stabilizes GitHub Actions Node.js runtime usage for testing and release automation documentation consistency.
+
+## Highlights
+- Updated test workflow matrix from `20.x/24.x` to `20.x/22.x` for active LTS compatibility.
+- Updated GitHub release workflow to `actions/checkout@v5` and added explicit Node setup (`actions/setup-node@v5`, `22.x`).
+- Synchronized release-facing docs and metadata with `v1.0.3`.
+
+## Validation Steps
+1. Re-run Test workflow matrix jobs for Node 20 and 22.
+2. Re-run release workflow dispatch to ensure the updated action/runtime path executes cleanly.
+
+---
+
 # Release Notes - Production Deployment 2026-04-02
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fused-gaming/mcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Modular MCP server with scalable Claude skills for Fused Gaming and VLN Security",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Motivation
- CI test jobs were failing due to Node runtime mismatch and deprecated action references, and release/docs metadata needed to be kept in sync with workflow expectations.

### Description
- Updated `.github/workflows/test.yml` to run the Node matrix on active LTS lanes `20.x` and `22.x` instead of `20.x`/`24.x` and kept `actions/setup-node@v5`/`actions/checkout@v5` usage.
- Updated `.github/workflows/github-release.yml` to use `actions/checkout@v5` and added an explicit `actions/setup-node@v5` step using `22.x` for consistent release-job Node runtime.
- Bumped release metadata from `1.0.2` to `1.0.3` in `package.json` and `VERSION.json` and updated changelog/README/release notes/roadmap/docs to reflect `v1.0.3` and the node-lane stabilization.
- Synchronized docs and examples (including `docs/NPM_PUBLISHING.md`, `docs/RELEASE_COMMUNICATION.md`, `docs/ROADMAP.md`, `docs/releases/RELEASE_NOTES.md`, `CHANGELOG.md`, `CLAUDE.md`) to remove outdated action/runtime snippets and document the Node workflow change.

### Testing
- Ran `npm install --package-lock-only --ignore-scripts` locally to refresh lockfile metadata and this failed with `E403` from the npm registry for `mermaid`, so lockfile/install validation could not complete in this environment.
- Ran `npm run lint --if-present` which failed due to missing installed dev-dependencies (`@typescript-eslint/parser`) caused by the blocked install step.
- Queried GitHub PRs via the public API (`curl` to `api.github.com`) which returned `HTTP/1.1 403 Forbidden`, preventing remote CI/PR status verification in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0bb78ddf8832882ef2ffc789996d8)