### PR TITLE
fix(ci): resolve PR #73 node test merge failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Replaced placeholder Jest test commands in `mermaid-terminal`, `svg-generator`, and `ux-journeymapper` workspace packages with shell no-op test scripts so CI does not fail with `jest: command not found` during PR merge checks.
 - Resolved Node `24.x` CI workspace discovery failure (`EDUPLICATEWORKSPACE`) by assigning the legacy Mermaid package a unique workspace name (`@fused-gaming/skill-mermaid-terminal-legacy`) after the production `mermaid-terminal` merge.
 - Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,19 @@
 ### Follow-up for Next Agent
 1. Validate publish workflow on a tag in GitHub Actions with npm registry access.
 2. If any package requires a non-patch bump policy, add a strategy flag to `prepare-publish-versions.cjs`.
+
+## Agent Notes (2026-04-16, PR #73 Node Test Failure)
+
+### Root Cause
+- Three skill workspaces used placeholder test scripts (`jest --passWithNoTests`) but `jest` is not installed in the monorepo, causing CI `npm test --workspaces` to fail on merge checks.
+
+### Fix Applied
+- Updated test scripts in:
+  - `packages/skills/mermaid-terminal/package.json`
+  - `packages/skills/svg-generator/package.json`
+  - `packages/skills/ux-journeymapper/package.json`
+- All three now use `echo "No tests yet"` to keep pipeline green until real tests are implemented.
+
+### Follow-up
+1. Add a shared test runner dependency (Jest or Vitest) only when real test suites are introduced.
+2. Replace placeholder test scripts with runnable tests as each skill reaches implementation phase.

--- a/packages/skills/mermaid-terminal/package.json
+++ b/packages/skills/mermaid-terminal/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "dev": "tsc --project tsconfig.json --watch",
-    "test": "jest --passWithNoTests",
+    "test": "echo \"No tests yet\"",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/skills/svg-generator/package.json
+++ b/packages/skills/svg-generator/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "dev": "tsc --project tsconfig.json --watch",
-    "test": "jest --passWithNoTests",
+    "test": "echo \"No tests yet\"",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/skills/ux-journeymapper/package.json
+++ b/packages/skills/ux-journeymapper/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "dev": "tsc --project tsconfig.json --watch",
-    "test": "jest --passWithNoTests",
+    "test": "echo \"No tests yet\"",
     "test:watch": "jest --watch"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Fix failing Node workspace test phase during PR #73 merges where `jest` was invoked from workspaces that do not guarantee Jest is installed, causing merge checks to error.

### Description
- Replaced `test` scripts calling `jest --passWithNoTests` with `echo "No tests yet"` in `packages/skills/mermaid-terminal/package.json`, `packages/skills/svg-generator/package.json`, and `packages/skills/ux-journeymapper/package.json`, and updated `CHANGELOG.md` and `CLAUDE.md` with the fix and follow-up guidance.

### Testing
- Ran `npm test --workspaces --if-present` which completed successfully across workspaces; `npm ci` failed in this environment due to an npm registry `403` (network restriction), so full install/build checks should be validated in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d17075348328bda2234ebc5e95f7)