### PR TITLE
fix(lint): underscore unused params in mermaid and ux-journeymapper tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,3 +133,13 @@
 ### Follow-up
 1. Add a shared test runner dependency (Jest or Vitest) only when real test suites are introduced.
 2. Replace placeholder test scripts with runnable tests as each skill reaches implementation phase.
+
+## Agent Notes (2026-04-16, Lint Unused-Args Cleanup)
+
+### What Was Fixed
+- Resolved `@typescript-eslint/no-unused-vars` failures in skill tools by renaming intentionally unused parameters to underscore-prefixed names in:
+  - `packages/skills/mermaid-terminal/src/tools/generate-mermaid-diagram.ts`
+  - `packages/skills/ux-journeymapper/src/tools/map-user-journey.ts`
+
+### Validation
+1. `npm run lint -- packages/skills/mermaid-terminal/src/tools/generate-mermaid-diagram.ts packages/skills/ux-journeymapper/src/tools/map-user-journey.ts` passes locally.

--- a/packages/skills/mermaid-terminal/src/tools/generate-mermaid-diagram.ts
+++ b/packages/skills/mermaid-terminal/src/tools/generate-mermaid-diagram.ts
@@ -57,7 +57,7 @@ function detectDiagramType(objective: string): string {
 /**
  * Generates a basic flowchart diagram from objective description
  */
-function generateFlowchart(objective: string, context: string): string {
+function generateFlowchart(objective: string, _context: string): string {
   const lines = objective.split(/[,;.]/);
   const steps = lines.filter((l) => l.trim().length > 0).slice(0, 5);
 
@@ -120,7 +120,7 @@ function generateSequenceDiagram(objective: string, context: string): string {
 /**
  * Generates a state diagram for state-based objectives
  */
-function generateStateDiagram(objective: string, context: string): string {
+function generateStateDiagram(objective: string, _context: string): string {
   const states = objective
     .split(/[,;]/)
     .filter((s) => s.trim().length > 0)

--- a/packages/skills/ux-journeymapper/src/tools/map-user-journey.ts
+++ b/packages/skills/ux-journeymapper/src/tools/map-user-journey.ts
@@ -77,8 +77,8 @@ function extractStages(objective: string): string[] {
  */
 function generateTouchpoints(
   stage: string,
-  objective: string,
-  context: string
+  _objective: string,
+  _context: string
 ): string[] {
   const stageLower = stage.toLowerCase();
 
@@ -153,7 +153,7 @@ function generateTouchpoints(
 /**
  * Generates pain points for a stage
  */
-function generatePainPoints(stage: string, objective: string): string[] {
+function generatePainPoints(stage: string, _objective: string): string[] {
   const stageLower = stage.toLowerCase();
 
   const painPointMap: Record<string, string[]> = {


### PR DESCRIPTION
### Motivation
- ESLint `@typescript-eslint/no-unused-vars` was failing for intentionally unused parameters (`context`, `objective`) in two skill tool modules and needed to follow the repo rule that unused args must be underscore-prefixed.
- The change preserves existing behavior while satisfying lint rules to unblock CI lint gates and PR checks.

### Description
- Renamed intentionally unused parameters to underscore-prefixed names in the following helper signatures: `generateFlowchart(..., _context)` and `generateStateDiagram(..., _context)` in `packages/skills/mermaid-terminal/src/tools/generate-mermaid-diagram.ts`.
- Renamed intentionally unused parameters to ` _objective`/`_context` in `generateTouchpoints(stage, _objective, _context)` and `generatePainPoints(stage, _objective)` in `packages/skills/ux-journeymapper/src/tools/map-user-journey.ts`.
- No functional logic or return values were changed; this is a signature-only cleanup to satisfy ESLint.
- Added an entry to `CLAUDE.md` documenting the lint fix and the validation command for next-agent handoff.

### Testing
- Ran the targeted linter command `npm run lint -- packages/skills/mermaid-terminal/src/tools/generate-mermaid-diagram.ts packages/skills/ux-journeymapper/src/tools/map-user-journey.ts` and it completed successfully (lint pass).
- No unit/integration tests were modified or required for this signature-only change.
- Repository-level CI checks that require authenticated GitHub CLI/API visibility were not executed in this environment and should be validated in the remote CI after merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d693b0e88328b46c28e9c9f41f37)