### PR TITLE
fix(ci): resolve PR #73 TypeScript 'width' regression and add validated update standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added scaffold packages for upcoming skills: mermaid-terminal, ux-journeymapper, svg-generator, project-manager, project-status-tool, daily-review, multi-account-session-tracking, and linkedin-master-journalist.
 
 ### Changed
+- Added a validated update standard to `docs/NPM_PUBLISHING.md` requiring typecheck/lint/build/tests/publish-prepare before version bumps or release tagging.
 - Updated `.github/workflows/test.yml` Node matrix from `20.x`/`24.x` to active LTS lanes `20.x`/`22.x` to resolve Actions Node-version failures in CI testing.
 - Updated `.github/workflows/github-release.yml` to `actions/checkout@v5` and added an explicit `actions/setup-node@v5` (`22.x`) runtime step for consistent release-job Node behavior.
 - Added `npm run publish:prepare` to automatically bump workspace package patch versions when a matching npm version already exists.
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Fixed `packages/skills/svg-generator/src/tools/generate-svg-asset.ts` to define `width` in `generateButton`, resolving CI TypeScript failures (`Cannot find name 'width'`) reported in PR #73 workflow annotations.
 - Updated publish version bump automation to only consider changed workspace packages when checking for already-published npm versions, preventing unrelated packages from being patch-bumped without source changes.
 - Aligned workflow runtime expectations and release docs around Node.js LTS lanes (`20.x`, `22.x`) to prevent test matrix Node-version mismatches.
 - Replaced placeholder Jest test commands in `mermaid-terminal`, `svg-generator`, and `ux-journeymapper` workspace packages with shell no-op test scripts so CI does not fail with `jest: command not found` during PR merge checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,3 +156,16 @@
 ### Next-Agent Validation
 1. In CI, verify `GITHUB_EVENT_BEFORE` is present for push events so changed-package detection is accurate.
 2. For manual runs, set `VERSION_BUMP_BASE_REF=<sha>` when comparing against a non-default baseline.
+
+## Agent Notes (2026-04-16, PR #73 Typecheck Regression + Versioning Standard)
+
+### What Was Fixed
+- Resolved TypeScript workflow failure in `packages/skills/svg-generator/src/tools/generate-svg-asset.ts` by defining the missing `width` constant in `generateButton(...)`.
+- This unblocks CI jobs that execute TypeScript compilation during dependency/install lifecycle.
+
+### Versioning Standard Update
+- `docs/NPM_PUBLISHING.md` now includes a **Validated Update Standards** sequence requiring `typecheck`, `lint`, `build`, workspace tests, and `publish:prepare` before any version bump or release tagging.
+
+### Next-Agent Reminder
+1. If workflow annotations show `Cannot find name 'width'`, verify the `generateButton` template variables in `generate-svg-asset.ts` first.
+2. Keep version/changelog updates coupled to a successful full validation pass (do not bump before checks are green).

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -190,6 +190,20 @@ Local commands:
 2. `npm run publish:preflight`
 3. `npm run publish:prepare` (runs both in sequence)
 
+
+### Validated Update Standards
+
+Before any version bump or publish-tag action, complete this validation sequence:
+
+1. `npm run typecheck`
+2. `npm run lint`
+3. `npm run build`
+4. `npm test --workspaces --if-present`
+5. `npm run publish:prepare`
+
+Only proceed to `npm version ...` and release tagging when all checks pass.
+If any check fails, fix code first and re-run the full sequence so version/changelog updates only represent validated changes.
+
 ## Automated CI/CD
 
 ### GitHub Actions Setup

--- a/packages/skills/svg-generator/src/tools/generate-svg-asset.ts
+++ b/packages/skills/svg-generator/src/tools/generate-svg-asset.ts
@@ -148,6 +148,7 @@ function generateButton(
   color: string,
   label: string = "Button"
 ): string {
+  const width = size;
   const height = size * 0.4;
   const textSize = height * 0.6;
 


### PR DESCRIPTION
### Motivation
- Fix the TypeScript regression that caused PR #73 workflow failures where `Cannot find name 'width'` was reported during `typecheck`.
- Prevent future release/versioning errors by enforcing a validated update sequence so version bumps/tags only occur after successful code validation.

### Description
- Define the missing `width` constant in `generateButton(...)` within `packages/skills/svg-generator/src/tools/generate-svg-asset.ts` to resolve the TypeScript errors.
- Add a "Validated Update Standards" sequence to `docs/NPM_PUBLISHING.md` requiring `typecheck`, `lint`, `build`, workspace tests, and `publish:prepare` before any version bump or release tagging.
- Record the fix and the new versioning guidance in `CHANGELOG.md` and add next-agent guardrails to `CLAUDE.md` to aid future triage.
- Bundle these edits into a PR titled to indicate the CI/typecheck fix and tightened versioning standards.

### Testing
- Ran `npm run typecheck` and the TypeScript compilation passed successfully.
- Ran `npm run lint` and the linter completed without errors.
- Ran `npm run build` and the workspace build completed successfully.
- Ran `npm test --workspaces --if-present` and workspace placeholder tests executed without failures.
- Local validation commands completed successfully and the original `Cannot find name 'width'` errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dadf42848328aabca576f8022bdd)