### PR TITLE
docs(release): sync lockfile, add issue specifications, and bump version to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - TBD for next release
 
+## [1.0.3] - 2026-04-16
+
+### Added
+- Added explicit issue-level specifications to roadmap milestone buckets and PR #51 checklist guidance to standardize execution evidence.
+
+### Changed
+- Updated blocker/current-step/next-step planning to include dependency install runtime constraints and dependency-validation follow-up tasks.
+- Bumped repository metadata/version references to `1.0.3` across `package.json`, `VERSION.json`, and README badge.
+
+### Fixed
+- Re-synchronized `package-lock.json` metadata with current workspace manifests using `npm install --package-lock-only --ignore-scripts`.
+
 ## [1.0.1] - 2026-04-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,19 @@
 ### Validation Notes
 1. Workspace tests still execute (`npm run test --workspaces --if-present`), but are mostly placeholder scripts.
 2. Lockfile/dependency sync remains blocked in this environment by npm registry HTTP 403 on `mermaid` (`npm install --package-lock-only --ignore-scripts`).
+
+## Agent Notes (2026-04-16, v1.0.3 Lockfile + Issue Specification Sync)
+
+### What Was Updated
+- Executed `npm install --package-lock-only --ignore-scripts` successfully to ensure lock metadata aligns with workspace manifests.
+- Expanded `docs/ROADMAP.md` milestone issue buckets to include issue-by-issue specification criteria.
+- Converted PR #51 checklist document into explicit checklist format and added required evidence fields.
+- Bumped repository metadata from `1.0.2` to `1.0.3` (`package.json`, `VERSION.json`, README badge, changelog/release notes).
+
+### Remaining Constraints
+1. `npm ci` can remain long-running/stalled in this runtime due proxy/network behavior, so dependency-install completion should be revalidated in unrestricted CI or local network.
+2. GitHub PR comments/check-runs/deployment details are still not directly queryable here without authenticated remote access.
+
+### Next-Agent Follow-up
+1. Re-run `npm ci`, `npm run lint`, `npm run typecheck`, and `npm run build` in a network-stable environment and attach logs to the active PR.
+2. Verify PR #51 and latest branch-related PR checks/deployments directly in GitHub UI, then update checklist evidence entries.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ npm run dev         # Start dev server
 
 ## 🗺️ Roadmap Snapshot (Existing + Planned)
 
-### Existing (v1.0.2)
+### Existing (v1.0.3)
 - ✅ 11 published `@h4shed/*` packages (core + CLI + 9 skills)
 - ✅ npm workspace publishing pipeline active on `main` and tags
 - ✅ Security baseline hardened (0 known vulnerabilities at last audit)
@@ -247,7 +247,7 @@ Apache 2.0 — See [LICENSE](./LICENSE) for details
 
 ---
 
-[![Version 1.0.2](https://img.shields.io/badge/version-1.0.2-blue)](./VERSION.json)
+[![Version 1.0.3](https://img.shields.io/badge/version-1.0.3-blue)](./VERSION.json)
 [![Released April 16, 2026](https://img.shields.io/badge/released-april%2016%2C%202026-brightgreen)](./docs/releases/RELEASE_NOTES.md)
 [![Status: Stable](https://img.shields.io/badge/status-stable-brightgreen)](./CHANGELOG.md)
 [![Maintained](https://img.shields.io/badge/maintained%3F-yes-brightgreen)](https://github.com/Fused-Gaming/Fused-Gaming-Skill-MCP)

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,16 +1,16 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "releaseDate": "2026-04-16",
   "status": "stable",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 2,
+  "patchVersion": 3,
   "prerelease": null,
   "metadata": {
     "nodeMinimum": "20.0.0",
     "npmMinimum": "8.0.0",
     "typescriptVersion": "5.3.2",
-    "buildNumber": 1003
+    "buildNumber": 1004
   },
   "packageInfo": {
     "name": "@fused-gaming/mcp",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,7 +123,8 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 1. GitHub CLI/API visibility is required to inspect live PR comments/check-runs from this environment.
 2. Newly scaffolded skills still need full tool logic, tests, and release tags before npm publication.
 3. Planned backlog is not yet mapped into implementation-ready milestones (owners, dates, dependencies).
-4. **Resolved (2026-04-16):** Node `24.x` `test` workflow duplicate workspace failure caused by two Mermaid workspaces sharing the same package name.
+4. Full dependency installation (`npm ci`) can hang in this runtime due network/proxy constraints, so clean install validation is partially blocked.
+5. **Resolved (2026-04-16):** Node `24.x` `test` workflow duplicate workspace failure caused by two Mermaid workspaces sharing the same package name.
 
 ## PR #51 Merge Readiness (Daily Review + Follow-on Skills)
 
@@ -140,15 +141,16 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 
 ## Current Steps
 
-1. Keep release-facing docs synchronized with actual `@h4shed` package publication.
-2. Finalize PR #51 merge-readiness docs/version/changelog updates.
-3. Complete implementation for newly scaffolded skills (after workspace collision fix validation).
-4. Keep release workflow docs synchronized with CI workflows.
+1. Resolve lockfile/dependency installation conflicts and re-confirm reproducible install path.
+2. Keep release-facing docs synchronized with actual `@h4shed` package publication.
+3. Finalize PR #51 merge-readiness docs/version/changelog updates.
+4. Complete implementation for newly scaffolded skills (after workspace collision fix validation).
+5. Keep release workflow docs synchronized with CI workflows.
 
 ## Immediate Next 3 Steps
 
 1. Verify PR #51 checks/deployments in GitHub UI and resolve any failing workflows before merge.
-2. Implement production logic + tests for `mermaid-terminal`, `ux-journeymapper`, `svg-generator`.
+2. Re-run `npm ci` in a full-network runtime and capture completion telemetry/log artifacts.
 3. Add CI validation to ensure docs package names stay aligned with published scope metadata.
 
 ---
@@ -157,19 +159,29 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 
 ### Milestone M1 — PR #51 Daily Review Merge Stabilization (target: immediate)
 - **Issue A:** Validate and document PR #51 check-run and deployment outcomes.
+  - **Specification:** record workflow URL, run ID, commit SHA, final conclusion, failing step (if any), and remediation commit reference.
 - **Issue B:** Keep changelog/version/docs synchronized in same merge window.
+  - **Specification:** `package.json`, `VERSION.json`, `README` version badge, and `CHANGELOG` release section must resolve to the same semantic version.
 - **Issue C:** Capture blocker/handoff notes for next agent to avoid duplicate triage.
+  - **Specification:** blockers list must include environment limits, attempted commands, and exact next owner action.
 
 ### Milestone M2 — Next-Wave Skill Completion (target: next release cycle)
 - **Issue A:** `skill-mermaid-terminal` implementation + tests.
+  - **Specification:** include at least one rendering command, one validation path, and one deterministic test fixture.
 - **Issue B:** `skill-ux-journeymapper` implementation + tests.
+  - **Specification:** include persona input schema validation, output structure contract, and snapshot coverage for default template output.
 - **Issue C:** `skill-svg-generator` implementation + tests.
+  - **Specification:** include strict dimension/color validation, deterministic SVG serialization, and fixture-driven regression checks.
 - **Issue D:** `skill-project-manager` and `skill-project-status-tool` MVP command sets.
+  - **Specification:** each package must expose typed input/output contracts and at least one CLI-usable command with unit tests.
 
 ### Milestone M3 — Planned Tooling and Release Observability (target: subsequent cycle)
 - **Issue A:** Unified PR release checklist with test/deploy evidence links.
+  - **Specification:** checklist entries must require a direct link to Actions run and pass/fail evidence timestamp.
 - **Issue B:** CI guardrails to detect docs/package/version drift.
+  - **Specification:** CI must fail when scope, version, or package inventory in docs diverges from workspace manifests.
 - **Issue C:** Automation for milestone issue template generation from roadmap backlog.
+  - **Specification:** script must parse roadmap issue bullets and emit prefilled issue templates including owner, target date, and dependencies.
 
 ---
 

--- a/docs/process/PR_51_MERGE_CHECKLIST.md
+++ b/docs/process/PR_51_MERGE_CHECKLIST.md
@@ -3,25 +3,26 @@
 ## Scope
 Prepare merge-ready documentation and versioning for PR #51 (daily review integration + planned follow-on skills/tools alignment).
 
-## Deliverables
-1. Update `README.md` roadmap snapshot and priority list.
-2. Update `docs/ROADMAP.md` blockers, current steps, and immediate next three steps.
-3. Add/refresh milestone + issue buckets for planned tools and skills.
-4. Bump repository version metadata for merge-window traceability.
-5. Update `CHANGELOG.md` for unreleased and versioned notes.
-6. Add agent handoff context to `CLAUDE.md`.
+## Deliverables Checklist
+- [x] Update `README.md` roadmap snapshot and priority list.
+- [x] Update `docs/ROADMAP.md` blockers, current steps, and immediate next three steps.
+- [x] Add/refresh milestone + issue buckets for planned tools and skills.
+- [x] Bump repository version metadata for merge-window traceability.
+- [x] Update `CHANGELOG.md` for unreleased and versioned notes.
+- [x] Add agent handoff context to `CLAUDE.md`.
 
-## Success Metrics
-- Documentation sections referenced above are internally consistent.
-- Version values match across `VERSION.json`, `package.json`, and README badge.
-- A clear blocker list exists and includes execution-environment constraints.
-- Immediate next three steps are explicit and actionable.
-- Milestone and issue buckets map to the planned tools/skills in roadmap.
+## Success Metrics Checklist
+- [x] Documentation sections referenced above are internally consistent.
+- [x] Version values match across `VERSION.json`, `package.json`, and README badge.
+- [x] A clear blocker list exists and includes execution-environment constraints.
+- [x] Immediate next three steps are explicit and actionable.
+- [x] Milestone and issue buckets map to the planned tools/skills in roadmap.
 
 ## Blockers
 1. GitHub CLI (`gh`) is not installed in this environment.
 2. No git remotes/API credentials are configured; live PR comments and check-runs cannot be queried from terminal.
 3. Deployment/test status for recent PRs must be verified in GitHub UI.
+4. `npm ci` dependency install can stall in this runtime under current proxy/network conditions.
 
 ## Current Steps
 1. Keep docs/version/changelog in sync for PR #51 review.
@@ -32,7 +33,7 @@ Prepare merge-ready documentation and versioning for PR #51 (daily review integr
 ## Immediate Next 3 Steps
 1. Open PR #51 in GitHub and confirm all checks + deployments are green.
 2. If any workflow fails, patch branch and rerun until green.
-3. Start implementation/test pass for `mermaid-terminal`, `ux-journeymapper`, and `svg-generator`.
+3. Re-run `npm ci` from an unrestricted network runtime and attach logs to the PR thread.
 
 ## Recent PRs Related to Current Branch (Local-Git Evidence)
 - `#44` fix(ci): recover publish flow from merged workspace-version conflicts.
@@ -42,6 +43,14 @@ Prepare merge-ready documentation and versioning for PR #51 (daily review integr
 - `#39` merge: migrate deprecated Node.js GitHub Actions references.
 
 > Note: live check/deploy state for the PRs above must be confirmed in GitHub UI due to local environment limitations.
+
+## Issue Specifications (required evidence per issue)
+- **Issue: PR check/deploy verification**
+  - Record workflow URL, run ID, commit SHA, conclusion, and failed step (if applicable).
+- **Issue: Version/doc sync**
+  - Confirm semantic version matches in `package.json`, `VERSION.json`, README version badge, and changelog release section.
+- **Issue: Dependency install health**
+  - Include install command used (`npm ci`), duration, and whether proxy/network constraints impacted completion.
 
 ## Agent Directives for Continuation
 - Prioritize workflow/deployment failures before new feature implementation.

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## 1.0.3 - 2026-04-16 (Lockfile + Issue Specification Sync)
+
+### Overview
+This patch release aligns planning/specification docs with active milestone issues and refreshes repository version metadata.
+
+### Included in this update
+- Added issue-level specification criteria to roadmap milestone issue buckets.
+- Updated PR #51 checklist with explicit completion checkboxes and required evidence fields.
+- Synchronized version references to `1.0.3` across release metadata and README badges.
+- Re-ran lockfile metadata synchronization (`npm install --package-lock-only --ignore-scripts`).
+
+### Known limitations
+- Full `npm ci` install validation remains runtime-dependent; this environment can stall under proxy/network constraints.
+
+---
+
 ## 1.0.1 - 2026-04-16 (PR #51 Merge-Readiness Update)
 
 ### Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fused-gaming/mcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fused-gaming/mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fused-gaming/mcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Modular MCP server with scalable Claude skills for Fused Gaming and VLN Security",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Motivation
- Resolve package-lock/version drift and workspace install conflicts by re-synchronizing lockfile metadata and aligning release metadata. 
- Make roadmap/milestone items actionable by adding explicit issue-level specifications and evidence requirements. 
- Improve PR #51 merge-readiness by converting checklist content to an actionable checklist and documenting dependency-install constraints for handoff.

### Description
- Bumped release metadata to `1.0.3` across `package.json`, `VERSION.json`, and root `package-lock.json`, and updated the README version badge. 
- Re-synchronized the root lockfile using `npm install --package-lock-only --ignore-scripts` so workspace manifests and lock metadata are aligned. 
- Expanded `docs/ROADMAP.md` and `docs/releases/RELEASE_NOTES.md` with issue-level specification criteria for M1/M2/M3 milestone buckets and updated `CHANGELOG.md` accordingly. 
- Converted `docs/process/PR_51_MERGE_CHECKLIST.md` into a checked checklist with required evidence fields, and appended next-agent handoff notes to `CLAUDE.md` describing runtime constraints and follow-up actions.

### Testing
- Ran `npm install --package-lock-only --ignore-scripts`, which completed successfully and updated the lockfile metadata. 
- Ran `npm run test --workspaces --if-present`, which completed successfully (packages currently contain placeholder/no-op tests). 
- Ran `npm run typecheck --workspaces --if-present`, which completed successfully with no blocking typecheck errors. 
- Ran `npm run build`, which failed in this runtime due to missing type-definition packages and npm registry/proxy restrictions (attempted `npm install -D @types/...` hit HTTP 403), so full build validation must be re-run in a network-stable environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e389e15c832880aa347f3e2c9c99)