### PR TITLE
fix(deploy): hoist CLI runtime deps for workspace builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Added root-level runtime dependencies for CLI UI modules (`boxen`, `chalk`, `figlet`, `gradient-string`, `inquirer`, `ora`, `yargs`) so workspace builds can resolve CLI imports consistently in deployment environments.
 - Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.
 - Regenerated `package-lock.json` to include newly scaffolded workspace packages so `npm ci` no longer fails after development→main merges.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,15 @@
 1. Verify PR #51 and related recent PR workflow/deployment states in GitHub UI.
 2. If any checks fail, fix those errors first and rerun workflows before additional feature work.
 3. Continue next-wave skill implementation (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`) after CI/deployment stability is confirmed.
+
+## Agent Notes (2026-04-16, Deployment Build Resolution)
+
+### What Changed
+- Promoted CLI runtime dependencies (`boxen`, `chalk`, `figlet`, `gradient-string`, `inquirer`, `ora`, `yargs`) to the root `package.json` `dependencies` block so monorepo root installs include modules needed by `packages/cli` TypeScript builds in deployment runtimes.
+
+### Why
+- Deployment logs showed `TS2307` module-resolution failures during workspace builds for `packages/cli` when these modules were not present at the root install boundary.
+
+### Next Agent Check
+1. In CI/Vercel with full registry access, run a clean install and `npm run build` to confirm CLI module-resolution errors are resolved.
+2. If remaining failures are type-only, verify whether the install mode omits dev dependencies and adjust compile pipeline accordingly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,15 @@
         "packages/skills/*",
         "packages/cli"
       ],
+      "dependencies": {
+        "boxen": "^8.0.1",
+        "chalk": "^5.3.0",
+        "figlet": "^1.8.2",
+        "gradient-string": "^3.0.0",
+        "inquirer": "^12.9.4",
+        "ora": "^8.2.0",
+        "yargs": "^17.7.2"
+      },
       "devDependencies": {
         "@types/node": "^20.12.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",

--- a/package.json
+++ b/package.json
@@ -64,5 +64,14 @@
     "LICENSE",
     "VERSION.json",
     "docs/"
-  ]
+  ],
+  "dependencies": {
+    "boxen": "^8.0.1",
+    "chalk": "^5.3.0",
+    "figlet": "^1.8.2",
+    "gradient-string": "^3.0.0",
+    "inquirer": "^12.9.4",
+    "ora": "^8.2.0",
+    "yargs": "^17.7.2"
+  }
 }


### PR DESCRIPTION
### Motivation
- Deployment workspace builds failed with `TS2307` module-resolution errors for CLI UI imports because runtime UI packages used by `packages/cli` were not present at the root install boundary. 
- CI/Vercel build logs showed missing modules during TypeScript compilation of the CLI, causing the monorepo workspace build to fail in deployment environments. 
- Hoisting these runtime dependencies to the root will make root-level installs include the modules required for workspace TypeScript resolution in deployment runtimes.

### Description
- Added CLI runtime packages (`boxen`, `chalk`, `figlet`, `gradient-string`, `inquirer`, `ora`, `yargs`) to the root `package.json` `dependencies` so root installs satisfy `packages/cli` compile-time imports. 
- Updated `package-lock.json` to reflect the hoisted dependency graph and regenerated lock metadata. 
- Documented the change in `CHANGELOG.md` and added an agent handoff note in `CLAUDE.md` describing the fix and follow-up verification steps. 
- Opened a PR titled "fix(deploy): resolve CLI workspace module resolution during build" for review and CI validation.

### Testing
- Ran `npm run build --workspace=packages/core` which completed successfully. 
- Attempted full workspace build with `npm run build` but the environment failed to fetch packages from the registry (`403`), preventing full build verification in this runtime. 
- Ran `npm install --package-lock-only --ignore-scripts` successfully to refresh lockfile metadata, while `npm install --ignore-scripts` failed due to a registry `403` error in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16e70985c832898188a76bf09c213)