### PR TITLE
fix: prevent Vercel install failures from prepare-time workspace builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.
 - Regenerated `package-lock.json` to include newly scaffolded workspace packages so `npm ci` no longer fails after development→main merges.
+- Stopped running the monorepo workspace build from the root `prepare` hook so production `npm install` (for example on Vercel) no longer fails before workspace dependencies are installed.
 
 ### Security
 - TBD for next release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # CLAUDE.md
 
+## Agent Notes (2026-04-16, Vercel install failure fix)
+
+### Root Cause
+- Root `prepare` script invoked `npm run build` across all workspaces during `npm install`.
+- In production installs (such as Vercel), workspace package dependencies were not guaranteed to be present when that hook ran, causing TypeScript module resolution failures in `packages/cli`.
+
+### What Was Changed
+- Replaced root `prepare` build hook with a no-op message in `package.json`.
+- This prevents installation-time build failures; explicit CI/build steps should continue to call `npm run build`.
+
+### Next Agent Checks
+1. Confirm Vercel/CI install stage succeeds with the new prepare behavior.
+2. Verify the explicit build stage still runs and passes in environments that install all workspace dependencies.
+
 ## Agent Notes (2026-04-13)
 
 ### Environment / Dependency Constraints

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
     "dev": "npm run dev --workspace=packages/core",
-    "prepare": "npm run build",
+    "prepare": "node -e \"console.log('Prepare hook skipped: run `npm run build` explicitly when needed.')\"",
     "version": "node scripts/update-version.js && git add VERSION.json",
     "publish:packages": "npm publish --workspaces",
     "prerelease": "npm run build && npm run typecheck && npm run lint",


### PR DESCRIPTION
### Motivation
- Production installs (for example Vercel) were failing because the root `prepare` hook ran `npm run build` during `npm install`, triggering workspace builds before workspace dependencies were installed and causing TypeScript module-resolution errors (TS2307).
- The change prevents install-time build runs so installs complete reliably and CI remains the place to run full workspace builds.

### Description
- Replaced the root `prepare` script in `package.json` with a no-op message so `npm install` no longer invokes a workspace build during install.
- Documented the remediation in `CHANGELOG.md` under the `Fixed` section to explain why installs were failing and what changed.
- Added a new handoff note to `CLAUDE.md` describing the root cause, the fix, and the next validation steps for follow-up agents.

### Testing
- `npm run build --workspace=packages/cli` reproduced the TS2307 missing-module errors prior to the fix and therefore failed in this environment.
- `node -p "require('./package.json').scripts.prepare"` succeeded and shows the updated no-op prepare command.
- `npm install` / `npm ci` attempts in this restricted runner stalled or were killed due to prolonged network/npm behavior, so full install+build validation is pending and should be re-run in CI/Vercel where registry access is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16ebf48f083288c613939c6e2529b)