### PR TITLE
fix(cli): restore missing module declarations for child-branch builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Added missing CLI dependency declarations (`boxen`, `chalk`, `figlet`, `gradient-string`, `inquirer`, `ora`) plus type packages for `figlet`/`inquirer` to prevent TypeScript module resolution failures during workspace CLI builds in child branches/deploy environments.
 - Fixed `packages/skills/svg-generator/src/tools/generate-svg-asset.ts` to define `width` in `generateButton`, resolving CI TypeScript failures (`Cannot find name 'width'`) reported in PR #73 workflow annotations.
 - Updated publish version bump automation to only consider changed workspace packages when checking for already-published npm versions, preventing unrelated packages from being patch-bumped without source changes.
 - Aligned workflow runtime expectations and release docs around Node.js LTS lanes (`20.x`, `22.x`) to prevent test matrix Node-version mismatches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,3 +169,16 @@
 ### Next-Agent Reminder
 1. If workflow annotations show `Cannot find name 'width'`, verify the `generateButton` template variables in `generate-svg-asset.ts` first.
 2. Keep version/changelog updates coupled to a successful full validation pass (do not bump before checks are green).
+
+## Agent Notes (2026-04-17, CLI Child-Branch Build Dependency Resolution)
+
+### Root Cause Pattern
+- Child branches that include richer CLI UI command modules can fail TypeScript compilation with `TS2307` when optional CLI UI libraries are imported but not declared in `packages/cli/package.json`.
+- Missing modules observed in failures: `ora`, `chalk`, `gradient-string`, `figlet`, `inquirer`, `boxen`, plus type package gaps for `figlet`/`inquirer`.
+
+### Fix Applied
+- Added the missing CLI runtime dependencies and associated type packages to `packages/cli/package.json`.
+
+### Next-Agent Guardrail
+1. If CLI build fails with `TS2307` module errors, verify dependency declarations in `packages/cli/package.json` before debugging TypeScript config.
+2. In restricted environments, lockfile refresh may fail with npm `403`; validate dependency graph in CI with registry access.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,9 +14,17 @@
   },
   "dependencies": {
     "@fused-gaming/mcp-core": "*",
+    "boxen": "^8.0.1",
+    "chalk": "^5.6.2",
+    "figlet": "^1.9.2",
+    "gradient-string": "^3.0.0",
+    "inquirer": "^12.10.0",
+    "ora": "^9.0.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@types/figlet": "^1.7.0",
+    "@types/inquirer": "^9.0.9",
     "@types/node": "^20.12.0",
     "@types/yargs": "^17.0.24",
     "typescript": "^5.3.2"


### PR DESCRIPTION
### Motivation
- Child-branch and CI workspace TypeScript builds were failing with `TS2307` module-resolution errors for CLI UI imports because optional UI libraries were imported but not declared in the CLI workspace manifest. 
- The goal is to ensure `packages/cli` compiles reliably in child branches and CI workspace builds and to record the remediation and next-agent guardrails.

### Description
- Added runtime dependencies `boxen`, `chalk`, `figlet`, `gradient-string`, `inquirer`, and `ora` to `packages/cli/package.json` to restore missing module declarations. 
- Added dev type packages `@types/figlet` and `@types/inquirer` to resolve TypeScript type resolution during compilation. 
- Updated `CHANGELOG.md` under `Unreleased → Fixed` to document the remediation and updated `CLAUDE.md` with root-cause notes and next-agent guardrails for this failure pattern.

### Testing
- Ran `npm run build --workspace=packages/cli` which completed successfully and resolved the previous CLI `TS2307` build errors. 
- Ran the full workspace build with `npm run build` which completed successfully and emitted no missing-module TypeScript errors for the CLI. 
- Attempted `npm install --package-lock-only --ignore-scripts` to refresh lockfile metadata but it failed with an `E403` fetching `@types/figlet` due to registry restrictions in this environment, so CI should regenerate lockfile in a full-network environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e197e940f48328911c17db0ab666a8)