### PR TITLE
fix(vercel): align skill TypeScript configs with workspace defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD for next release
 
 ### Fixed
+- Normalized `packages/skills/daily-review-skill/tsconfig.json` and `packages/skills/underworld-writer-skill/tsconfig.json` to extend the workspace root TypeScript config so build environments (including Vercel) no longer attempt to load unrelated ambient `@types/*` libraries and fail with TS2688 during workspace builds.
 - Publish workflow now runs workspace version preparation and lockfile synchronization before `npm ci`/publish to prevent merge-order CI publish conflicts.
 - Updated GitHub Actions references to Node 24-compatible major versions (`actions/checkout@v5`, `actions/setup-node@v5`) across workflow docs and execution guides to prevent deprecation drift.
 - Regenerated `package-lock.json` to include newly scaffolded workspace packages so `npm ci` no longer fails after development→main merges.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # CLAUDE.md
 
+## Agent Notes (2026-04-17, Vercel TypeScript ambient types failure fix)
+
+### Root Cause
+- `packages/skills/daily-review-skill/tsconfig.json` and `packages/skills/underworld-writer-skill/tsconfig.json` were standalone and did not inherit root compiler settings (`types: ["node"]`).
+- During monorepo workspace builds, TypeScript attempted to include ambient `@types/*` entries from transitive dependencies, producing TS2688 missing-type-library errors in CI/Vercel.
+
+### What Was Changed
+- Updated `packages/skills/daily-review-skill/tsconfig.json` and `packages/skills/underworld-writer-skill/tsconfig.json` to extend `../../../tsconfig.json` and keep only package-local `rootDir`/`outDir` overrides.
+- This aligns the package with the other workspace tsconfig patterns and constrains default ambient type loading.
+
+### Next Agent Checks
+1. Re-run Vercel deployment for the branch and confirm build no longer fails with TS2688 type-definition lookup errors.
+2. Keep new package tsconfigs aligned with the workspace-extends pattern to prevent ambient type drift regressions.
+
 ## Agent Notes (2026-04-16, Vercel install failure fix)
 
 ### Root Cause

--- a/packages/skills/daily-review-skill/tsconfig.json
+++ b/packages/skills/daily-review-skill/tsconfig.json
@@ -1,19 +1,8 @@
 {
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
     "rootDir": "./src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "tests"]

--- a/packages/skills/underworld-writer-skill/tsconfig.json
+++ b/packages/skills/underworld-writer-skill/tsconfig.json
@@ -1,18 +1,8 @@
 {
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
-    "lib": ["ES2020"],
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
### Motivation
- Vercel and CI workspace builds were failing with TypeScript `TS2688` errors because two skill packages had standalone `tsconfig.json` files that did not inherit the repo-wide compiler defaults (including ambient `types`).
- The intent is to constrain ambient type loading and make per-package builds behave like the rest of the monorepo so production installs and remote builds (for example Vercel) do not attempt to resolve unrelated `@types/*` libraries during workspace builds.

### Description
- Updated `packages/skills/daily-review-skill/tsconfig.json` to `extends` the root `tsconfig.json` and keep only package-local `rootDir`/`outDir` overrides so it inherits workspace compiler defaults.
- Updated `packages/skills/underworld-writer-skill/tsconfig.json` to `extends` the root `tsconfig.json` and keep only package-local `rootDir`/`outDir` overrides so it matches the workspace pattern.
- Recorded the change in `CHANGELOG.md` under the **Unreleased → Fixed** section and added an operational note and next-agent checks in `CLAUDE.md` describing the root cause and validation steps.

### Testing
- Ran `npm run build --workspace=packages/skills/daily-review-skill` and the build completed successfully. 
- Ran `npm run build --workspace=packages/skills/underworld-writer-skill` and the build completed successfully. 
- A full workspace `npm run build` previously failed with `TS2688` errors in the affected skill packages before this change, and full-workspace validation remains constrained by incomplete install steps in this environment (`npm install`/`npm ci` showed install/rename errors and networking/proxy warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19f4a951883288cf95bc5faebeec6)