### PR TITLE
docs: orient GitHub MCP agents on feat/github-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `docs/process/GITHUB_MCP_AGENTS_ORIENTATION.md` with blockers, current steps, immediate next actions, PR-context triage, and agent directives for the `feat/github-agents` branch.
 - Added `docs/process/PR_51_MERGE_CHECKLIST.md` with explicit PR #51 deliverables, success metrics, blockers, execution order, and next-agent handoff directives.
 - Added `scripts/auto-bump-publish-versions.js` to automatically patch-bump root/workspace package versions until npm reports they are publishable.
 - Added `scripts/preflight-publish-check.js` and wired it into publish CI to fail fast when any workspace package version is already published on npm.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,3 +196,16 @@
 ### Next-Agent Guardrail
 1. If CLI build fails with `TS2307` module errors, verify dependency declarations in `packages/cli/package.json` before debugging TypeScript config.
 2. In restricted environments, lockfile refresh may fail with npm `403`; validate dependency graph in CI with registry access.
+
+## Agent Notes (2026-04-17, GitHub MCP Agents Orientation Branch)
+
+### Session Output
+- Created branch `feat/github-agents` and added `docs/process/GITHUB_MCP_AGENTS_ORIENTATION.md`.
+- Captured blockers, current steps, immediate next 3 steps, open-issue execution plan, top-3 priorities, and role-based agent directives.
+
+### Blocking Constraint
+- GitHub check/deployment verification remains blocked in this environment due unavailable authenticated GitHub CLI/API access.
+
+### Next-Agent Starter
+1. Run authenticated GitHub PR/check/deployment inspection first; fix any failing checks before starting new feature implementation.
+2. Keep `CHANGELOG.md`, `docs/ROADMAP.md`, and `CLAUDE.md` synchronized after each merge.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -180,3 +180,14 @@ The active public npm scope is currently `@h4shed` (not an npm org scope).
 - `#14` merge for underworld writer feature delivery
 
 CI/deployment status for these PRs must be verified in GitHub UI/API.
+
+---
+
+## GitHub MCP Agents Branch Snapshot (2026-04-17)
+
+- Active planning branch: `feat/github-agents`.
+- Orientation/runbook added at `docs/process/GITHUB_MCP_AGENTS_ORIENTATION.md`.
+- Priority focus remains:
+  1. Authenticated visibility for PR checks/deployments.
+  2. Failing-check-first remediation policy.
+  3. Queued skill implementation with full validation and handoff discipline.

--- a/docs/process/GITHUB_MCP_AGENTS_ORIENTATION.md
+++ b/docs/process/GITHUB_MCP_AGENTS_ORIENTATION.md
@@ -1,0 +1,90 @@
+# GitHub MCP Agents Orientation (feat/github-agents)
+
+_Date: 2026-04-17_
+
+## Deliverables and Success Metrics
+
+1. Create and use feature branch `feat/github-agents` for GitHub MCP agent rollout planning.
+2. Produce an execution-oriented status snapshot that includes blockers, current steps, and immediate next 3 steps.
+3. Inventory recent PR context and clearly separate confirmed facts from environment blockers.
+4. Define top-3 prioritized items and assign actionable agent directives for implementation continuity.
+
+## Blockers
+
+1. GitHub CLI and authenticated API access are unavailable in this runtime, so live PR comments/check-runs/deployment outcomes cannot be verified directly.
+2. No deployment-capable runtime credentials are available for performing actual remote deployments from this environment.
+3. Several queued skills remain scaffold-level; agent deployment depends on implementation/test readiness by workspace owners.
+
+## Current Steps
+
+1. Keep roadmap/version/changelog documentation synchronized with active CI and release strategy.
+2. Validate Node LTS CI lanes (`20.x`, `22.x`) and keep workflow docs aligned with runtime truth.
+3. Complete production logic + tests for queued skills before publication.
+4. Maintain explicit handoff notes in `CLAUDE.md` to reduce repeated triage work between agent sessions.
+
+## Immediate Next 3 Steps
+
+1. Verify recent PR checks/deployments from an authenticated GitHub session and log outcomes in this document.
+2. Implement and test one queued skill end-to-end (`mermaid-terminal` recommended first), then run full workspace validation.
+3. Add a lightweight status artifact (JSON/Markdown) generated in CI that captures PR readiness signals for agent ingestion.
+
+## Recent Pull Requests (Local Git History View)
+
+> Source: `git log --oneline --decorate -n 25` in this repository.
+
+- `#92` Development
+- `#80` `fix(ci): resolve PR #73 width typecheck failure`
+- `#78` `fix(publish): bump only changed workspaces`
+- `#77` `fix(lint): rename unused tool params with underscore prefix`
+- `#76` `fix(ci): remove missing jest test placeholders for PR #73`
+- `#75` Feature/mermaid terminal skill
+- `#73` Merge pull request from `development`
+- `#72`, `#71`, `#69`, `#68`, `#67`, `#52`, `#51`, `#44`, `#43`, `#32`, `#30`, `#20`, `#14`
+
+### PR Status / Test & Deployment Notes
+
+- **Known from repository context**: multiple PRs targeted CI/publish/test stability.
+- **Not directly verifiable here**: per-PR check-run status, deployment environments, and comment threads (blocked by missing authenticated GitHub access).
+- **Required follow-up**: confirm test/deploy conclusions in GitHub Actions UI and sync any failures back into this plan.
+
+## Open-Issue Check and Resolution Plan
+
+### Open issues requiring attention now
+
+1. Missing authenticated check/deployment visibility (high priority).
+2. Incomplete implementation/testing for queued skills (high priority).
+3. Lack of standardized, machine-readable readiness summary for agent orchestration (medium priority).
+
+### Execution Plan
+
+1. **Visibility unblock**: run authenticated `gh pr list`/`gh pr view` and capture checks/deploy outcomes.
+2. **Stabilize first failing item**: if any PR shows failed checks/deploy, fix that failure before starting new feature work.
+3. **Agent-enable rollout**: once green, proceed with prioritized agent directives below.
+
+## Top 3 Prioritized Items
+
+1. **CI/Deployment Signal Visibility** — unblock authenticated inspection and create a durable status log.
+2. **Queued Skill Production Readiness** — deliver at least one queued skill with tests and lint/typecheck/build pass.
+3. **Agent-Oriented Execution Protocol** — enforce repeatable directives + handoff structure for multi-agent continuity.
+
+## Agent Directives (Deployment-Oriented)
+
+### Agent A: CI Visibility Agent
+- Authenticate GitHub tooling.
+- Export PR check/deployment summaries for recent PRs and active branch PR.
+- Stop and escalate if any required checks are red.
+
+### Agent B: Skill Stabilization Agent
+- Pick highest-impact queued skill.
+- Implement core tool flow + tests.
+- Run `npm run lint`, `npm run typecheck`, `npm run build`, and workspace tests.
+
+### Agent C: Documentation & Handoff Agent
+- Update `CHANGELOG.md`, `docs/ROADMAP.md`, and `CLAUDE.md` after each stabilized merge.
+- Maintain concise session handoff entries: blocker, action taken, next concrete command.
+
+## Handoff Notes for Next Agent
+
+- Branch in use: `feat/github-agents`.
+- This session established planning and prioritization artifacts; no remote PR/deployment statuses could be verified due to environment authentication limits.
+- Start next session by pulling authenticated PR check/deployment data and resolving any red checks before new feature additions.


### PR DESCRIPTION
### Motivation
- Create a dedicated feature branch and onboarding artifact to orient GitHub-focused agents and capture deliverables, blockers, priorities, and handoff instructions for continued work on agent-driven tasks.
- Ensure repository documentation and release-tracking artifacts record the branch snapshot so future agents can resume triage without repeating discovery steps.

### Description
- Created and switched to branch `feat/github-agents` and added the orientation/runbook at `docs/process/GITHUB_MCP_AGENTS_ORIENTATION.md` that lists deliverables, blockers, current steps, immediate next 3 steps, PR-context, and agent directives.
- Appended a branch snapshot section to `docs/ROADMAP.md` describing the branch focus and link to the new runbook.
- Updated `CHANGELOG.md` (Unreleased Added) to record the new orientation document and appended session notes to `CLAUDE.md` so next agents have a concrete starter checklist.
- Committed the documentation changes and opened a PR titled `docs: orient GitHub MCP agents on feat/github-agents` with an explicit summary and success metrics.

### Testing
- Ran `git diff --check` which passed to validate there are no whitespace or index errors on the patch.
- Verified commits and branch state via `git status`/`git log` confirming the docs-only changes; no code, build, or runtime tests were required because only documentation files were modified.
- Attempted to list remote PRs with `gh` but GitHub CLI is unavailable/unauthenticated in this environment, so live CI/check-run validation must be performed from an authenticated session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c7dfcce0832889339b1952d15936)