### PR TITLE
feat(cli): one-command SyncPulse panel launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added one-command SyncPulse panel launcher commands to the CLI: `fused-gaming-mcp panel` and `fused-gaming-mcp syncpulse` (alias).
 - Added `docs/process/PR_51_MERGE_CHECKLIST.md` with explicit PR #51 deliverables, success metrics, blockers, execution order, and next-agent handoff directives.
 - Added `scripts/auto-bump-publish-versions.js` to automatically patch-bump root/workspace package versions until npm reports they are publishable.
 - Added `scripts/preflight-publish-check.js` and wired it into publish CI to fail fast when any workspace package version is already published on npm.
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added scaffold packages for upcoming skills: mermaid-terminal, ux-journeymapper, svg-generator, project-manager, project-status-tool, daily-review, multi-account-session-tracking, and linkedin-master-journalist.
 
 ### Changed
+- Updated CLI and root README command references to document the new one-command SyncPulse panel launcher.
 - Added a validated update standard to `docs/NPM_PUBLISHING.md` requiring typecheck/lint/build/tests/publish-prepare before version bumps or release tagging.
 - Updated `.github/workflows/test.yml` Node matrix from `20.x`/`24.x` to active LTS lanes `20.x`/`22.x` to resolve Actions Node-version failures in CI testing.
 - Updated `.github/workflows/github-release.yml` to `actions/checkout@v5` and added an explicit `actions/setup-node@v5` (`22.x`) runtime step for consistent release-job Node behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,20 @@
 # CLAUDE.md
 
+## Agent Notes (2026-04-17, One-Command SyncPulse Panel Launcher)
+
+### What Was Added
+- CLI now supports direct panel launch commands:
+  - `fused-gaming-mcp panel`
+  - `fused-gaming-mcp syncpulse` (alias)
+- Both commands run the existing boot sequence and then open the SyncPulse dashboard without entering the interactive main menu loop.
+
+### Why
+- Reduces operator friction for the SyncPulse workflow by providing a single-command launcher entrypoint.
+
+### Next-Agent Guardrail
+1. If adding new UI surfaces, keep direct-launch command aliases documented in both `README.md` and `packages/cli/README.md`.
+2. Validate launcher behavior with `npm run build --workspace=packages/cli` and a direct invocation (for example `node packages/cli/dist/index.js panel`) after build.
+
 ## Agent Notes (2026-04-16, Vercel install failure fix)
 
 ### Root Cause

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ fused-gaming-mcp init              # Initialize config
 fused-gaming-mcp list              # Show available skills
 fused-gaming-mcp add <skill>       # Enable a skill
 fused-gaming-mcp remove <skill>    # Disable a skill
+fused-gaming-mcp panel             # Launch SyncPulse panel directly
 fused-gaming-mcp config            # View current config
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,6 +16,17 @@ npm run build --workspace=packages/cli
 npm run test --workspace=packages/cli
 ```
 
+## Commands
+
+```bash
+fused-gaming-mcp init          # Generate config
+fused-gaming-mcp list          # List skills
+fused-gaming-mcp add <skill>   # Enable a skill
+fused-gaming-mcp remove <skill> # Disable a skill
+fused-gaming-mcp panel         # One-command SyncPulse panel launcher
+fused-gaming-mcp syncpulse     # Alias of `panel`
+```
+
 ## License
 
 Apache-2.0

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,11 @@ async function runInteractive() {
   console.log("👋 Goodbye");
 }
 
+async function launchSyncPulsePanel() {
+  await runBootSequence();
+  showSyncPulseDashboard();
+}
+
 // If no command provided → launch UI
 if (hideBin(process.argv).length === 0) {
   runInteractive();
@@ -68,6 +73,22 @@ if (hideBin(process.argv).length === 0) {
         }),
       async (argv: any) => {
         await add(argv.skill);
+      }
+    )
+    .command(
+      "panel",
+      "Launch the SyncPulse panel directly",
+      {},
+      async () => {
+        await launchSyncPulsePanel();
+      }
+    )
+    .command(
+      "syncpulse",
+      "Alias for launching the SyncPulse panel",
+      {},
+      async () => {
+        await launchSyncPulsePanel();
       }
     )
     .command(


### PR DESCRIPTION
### Motivation
- Provide a single-command launcher for the SyncPulse dashboard so operators can open the panel without entering the interactive main menu loop.
- Improve discoverability by documenting the new direct-launch commands in the CLI and root READMEs.

### Description
- Added `launchSyncPulsePanel()` to the CLI and wired two yargs commands: `panel` and `syncpulse` (alias) that run the boot sequence then open the SyncPulse dashboard (`packages/cli/src/index.ts`).
- Updated `packages/cli/README.md` and top-level `README.md` to document the new `fused-gaming-mcp panel` / `syncpulse` commands.
- Recorded the change in `CHANGELOG.md` under Unreleased and appended handoff/validation notes to `CLAUDE.md` to guide the next agent.

### Testing
- Ran `npm run build --workspace=packages/cli` to validate TypeScript compilation and the new CLI entrypoints, and the build failed with `TS2307` errors because required runtime dev dependencies were not installed in this environment (module resolution failures for `ora`, `chalk`, `figlet`, `gradient-string`, `inquirer`, `boxen`).
- Attempted `npm install --ignore-scripts` to provision dependencies but full install/build validation could not complete due to the environment's network/install constraints.
- No other automated tests were run in this session; docs updates and CLI wiring are included and await validation via full `npm install` and `npm run build` in a networked CI or developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cb097af08328a2aa4b16c2ef53b9)