### PR TITLE
docs: reindex README roadmap with open PR and milestone triage snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a 2026-04-21 PR/milestone triage snapshot in `README.md` covering current blockers, current steps, immediate next three steps, and active open PR queue.
 - Added `docs/process/GITHUB_MCP_AGENTS_ORIENTATION.md` with blockers, current steps, immediate next actions, PR-context triage, and agent directives for the `feat/github-agents` branch.
 - Added `docs/process/VERCEL_PROJECT_SETUP.md` with explicit Vercel project directory and framework preset guidance for `skills.vln.gg` (skills API) and `sync.vln.gg` (augmented agents app).
 - Added one-command SyncPulse panel launcher commands to the CLI: `fused-gaming-mcp panel` and `fused-gaming-mcp syncpulse` (alias).
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added scaffold packages for upcoming skills: mermaid-terminal, ux-journeymapper, svg-generator, project-manager, project-status-tool, daily-review, multi-account-session-tracking, and linkedin-master-journalist.
 
 ### Changed
+- Updated roadmap summary messaging in `README.md` to align with live GitHub open PR and milestone inventory instead of stale branch assumptions.
 - Added a validated update standard to `docs/NPM_PUBLISHING.md` requiring typecheck/lint/build/tests/publish-prepare before version bumps or release tagging.
 - Updated `.github/workflows/test.yml` Node matrix from `20.x`/`24.x` to active LTS lanes `20.x`/`22.x` to resolve Actions Node-version failures in CI testing.
 - Updated `.github/workflows/github-release.yml` to `actions/checkout@v5` and added an explicit `actions/setup-node@v5` (`22.x`) runtime step for consistent release-job Node behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,21 @@
 # CLAUDE.md
 
+## Agent Notes (2026-04-21, README roadmap + open PR/milestone reindex)
+
+### What Was Updated
+- Re-indexed public GitHub open PR and milestone state and synchronized root `README.md` roadmap snapshot with current April 2026 queue.
+- Added explicit lists for blockers, current execution steps, and immediate next 3 steps for next-agent orientation.
+- Updated `CHANGELOG.md` (`Unreleased`) to record this docs/triage refresh.
+
+### Constraints Encountered
+1. This environment has no git remote configured locally (`git remote -v` empty), so branch/PR linkage must be read from GitHub web pages rather than local remote refs.
+2. Unauthenticated GitHub page sections intermittently show `Uh oh!` loading errors for filters/check-run widgets; deployment/check conclusions should be re-verified in an authenticated session.
+
+### Next-Agent Focus
+1. Start with failing open PR checks/deployments (notably PR #101/#109 threads) and remediate before merging additional feature PRs.
+2. Keep root docs synchronized with GitHub milestone scope if milestone titles/descriptions are edited.
+3. Preserve changelog + README + version metadata update discipline on each merge-ready branch.
+
 ## Agent Notes (2026-04-17, Vercel TypeScript ambient types failure fix)
 
 ### Root Cause

--- a/README.md
+++ b/README.md
@@ -174,30 +174,56 @@ npm run dev         # Start dev server
 
 ## 🗺️ Roadmap Snapshot (Existing + Planned)
 
-### Existing (v1.0.4)
-- ✅ 11 published `@h4shed/*` packages (core + CLI + 9 skills)
-- ✅ npm workspace publishing pipeline active on `main` and tags
-- ✅ Security baseline hardened (0 known vulnerabilities at last audit)
+### Current repository state (as of April 21, 2026)
+- ✅ `VERSION.json` is `1.0.4` and marks the project `stable`.
+- ✅ 11 `@h4shed/*` packages are listed as published, with 9 additional skill packages queued for publish.
+- ✅ Core docs exist for roadmap/changelog/release orientation and package publishing workflow.
 
-### Planned (next release cycle)
-- 🔄 Promote release checklist automation from docs into CI validation gates
-- 🔄 Expand deployment verification for npm + GitHub release parity
-- 🔄 Add richer release announcement templates for community launch posts
-- 🔄 Merge and publish `daily-review` with release-quality docs and examples (PR #51 target)
-- 🔄 Publish and harden `agentic-flow-devkit` with tests + release workflow verification
-- 🔄 Implement tool logic + tests for `project-status-tool` and `project-manager`
-- 🔄 Formalize planned-tool milestones into trackable issue groups for weekly triage
+### Open PR queue (GitHub currently shows 8 open)
+> Source: https://github.com/Fused-Gaming/Fused-Gaming-Skill-MCP/pulls?q=is%3Apr+is%3Aopen
 
-### Current blockers to watch
-- GitHub PR/status triage currently depends on repository API/CLI availability in the execution environment.
-- Scope configuration (`NPM_SCOPE`) must be set in GitHub Actions variables for organization-owned publishing.
-- Without GitHub CLI/API credentials in the runtime, PR #51 check-run and deployment state must be confirmed directly in GitHub UI.
+1. `#109` Add LinkedIn Master Journalist (LIMJ) skill (base: `main`)
+2. `#101` ux-journeymapper implementation/docs refresh (base: `feature/syncpulse-skill-docs`)
+3. `#81` Feat/socials automation phase1
+4. `#79` Socials Automation Asset Pipeline - Phase 1
+5. `#19` SVG generation for canvas-design skill
+6. `#18` project status tool skill
+7. `#17` project manager skill
+8. `#16` multi-account session tracking skill
+
+### MVP milestone snapshot (GitHub milestones page)
+> Source: https://github.com/Fused-Gaming/Fused-Gaming-Skill-MCP/milestones
+
+- 14 milestones are open, including:
+  - `Syncpulse - AI Orchestration & Developer Control Plane`
+  - `Social Media Brand Asset Skill`
+  - `NPM Package Release` (closed issues complete)
+  - `SVG generation for Canvas Design Skill`
+  - `Project Manager Skill`
+  - `UX Journeymapper Skill`
+  - `Mermaid Terminal Skill`
+  - `Daily Review Skill`
+  - `Multi Account Session Tracking Skill`
+
+### Current blockers
+1. GitHub page/API content is partially degraded when unauthenticated (`Uh oh!` load failures on filters/check details), so some check-run evidence must be validated in an authenticated browser session.
+2. Open PR queue includes older April 2026 feature branches that need rebase/conflict/testing passes before merge sequencing.
+3. At least one open PR (`#101`) still shows a failed Vercel preview deployment signal in visible thread events.
+
+### Current steps
+1. Keep README/roadmap/changelog aligned with live GitHub PR + milestone state.
+2. Prioritize failing-deployment PR remediation before feature merges.
+3. Merge or close stale feature PRs with explicit branch strategy (stacked branch vs `main` direct).
+
+### Immediate next 3 steps
+1. Triage and fix failing deployment(s) on open PRs, starting with `#101`.
+2. Normalize open feature branches (`#16/#17/#18/#19/#79/#81/#101/#109`) against current `main`.
+3. Add/refresh a single merge checklist for each PR with test + deployment evidence links.
 
 ### Top 3 priorities now
-1. Ship missing high-impact skills (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`).
-2. Add automated docs/package consistency checks for published scope metadata.
-3. Track deployment/test status per release PR in a single release checklist.
-4. Keep Actions test matrix pinned to active LTS lanes (20.x, 22.x) to avoid Node-version runtime drift.
+1. Resolve failing open PR checks/deployments first (do not merge while red).
+2. Finish publish-ready implementation for missing high-impact skills (`mermaid-terminal`, `ux-journeymapper`, `svg-generator`, `project-*`).
+3. Automate docs/version/package drift checks in CI so release metadata stays accurate.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Synchronize the root roadmap and release-facing docs with the current public GitHub open PR and milestone state so planning artifacts are accurate for triage and handoff.
- Provide clear next-agent orientation (blockers, current steps, immediate next 3 steps, and top priorities) and record the docs change in the changelog for traceability.

### Description
- Updated `README.md` roadmap section to include current repository state, an explicit open PR queue (8 open), a snapshot of active milestones, current blockers, current steps, immediate next 3 steps, and top priorities.
- Appended `CLAUDE.md` with a new "Agent Notes (2026-04-21)" section that documents environment constraints (no local remote, unauthenticated GitHub UI limits) and next-agent focus items for PR remediation.
- Recorded the docs/triage refresh in `CHANGELOG.md` under `Unreleased` (`Added` and `Changed` entries) to preserve audit context.
- Prepared a PR describing the deliverables and success metrics for agent orientation and alignment with repository validation steps.

### Testing
- Ran `npm run lint` and the linter completed successfully with no new errors.
- Ran `npm run typecheck` (via `tsc --noEmit`) and TypeScript checks passed with no new errors.
- Verified the modified documentation files are consistent with repository static checks (lint + typecheck).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7525fcdac83288ce982d719d59380)