### PR TITLE
fix: Correct scaffold guide paths and working directory handling

### DIFF
--- a/docs/ECOSYSTEM_INFRASTRUCTURE_GUIDE.md
+++ b/docs/ECOSYSTEM_INFRASTRUCTURE_GUIDE.md
@@ -63,7 +63,7 @@ EOF
 # Create tsconfig.json
 cat > tsconfig.json <<EOF
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
@@ -115,19 +115,22 @@ import { YourSkill } from "@h4shed/skill-skill-name";
 Apache-2.0
 EOF
 
-# 5. Build and test locally
+# 5. Return to repository root
+cd ../../..
+
+# 6. Build and test locally
 npm run build --workspace=packages/skills/skill-name
 npm test --workspace=packages/skills/skill-name
 
-# 6. Commit changes
+# 7. Commit changes
 git add packages/skills/skill-name
 git commit -m "feat(skill-name): Add new skill with X tools"
 
-# 7. Push and create PR
+# 8. Push and create PR
 git push origin feat/skill-name
 # Create PR to main branch
 
-# 8. After merge, tag for publishing
+# 9. After merge, tag for publishing
 git tag skill-skill-name@1.0.0
 git push origin skill-skill-name@1.0.0
 


### PR DESCRIPTION
## Description

Resolves two P2 Codex review comments on the scaffold documentation guide.

## Changes

- **Fix 1 (Line 66)**: Correct tsconfig.json extends path
  - Was: `"extends": "../../tsconfig.json"` 
  - Now: `"extends": "../../../tsconfig.json"`
  - From `packages/skills/skill-name/` needs 3 segments to reach repo root

- **Fix 2 (Line 119)**: Add working directory reset
  - Added `cd ../../..` to return to repo root before workspace commands
  - Ensures `npm run build --workspace=packages/skills/skill-name` works correctly
  - Ensures `git add packages/skills/skill-name` uses correct relative path

- **Fix 3**: Corrected step numbering
  - Renumbered final steps to reflect added cd command

## Testing

✅ Path resolution tested and verified:
- tsconfig.json path correctly resolves from skill package to root
- Working directory correctly returns to repo root
- Workspace commands work from repo root with correct relative paths

## Checklist

- [x] Resolves Codex review feedback (P2 priority)
- [x] Paths tested and verified
- [x] Documentation is accurate
- [x] No linting errors
- [x] Ready for merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01En6YeD9JGPQK79MjDsoE9Y)_