### PR TITLE
fix(node-20): Fix LIMJ skill package.json JSON syntax error

### DIFF
--- a/packages/skills/linkedin-master-journalist/package.json
+++ b/packages/skills/linkedin-master-journalist/package.json
@@ -15,7 +15,6 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@h4shed/mcp-core": "*"
     "@h4shed/mcp-core": "^1.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Fixes the JSON syntax error in `packages/skills/linkedin-master-journalist/package.json` that was causing npm install failures.

## Error Fixed

```
npm error code EJSONPARSE
npm error JSON.parse Invalid package.json: JSONParseError: Expected ',' or '}' after property value in JSON at position 611
```

## Changes

- Removed duplicate `@h4shed/mcp-core` dependency declaration
- Consolidated to single valid dependency: `"@h4shed/mcp-core": "^1.0.4"`

## Verification

✅ JSON validation passes
✅ `npm install --package-lock-only --ignore-scripts` succeeds
✅ No package.json parse errors

Fixes CI/CD pipeline failures related to workspace dependency parsing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtEaicM46ymZvhoVuCg2en)_