### PR TITLE
fix: make GPG signing conditional on secret availability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
+        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -84,7 +85,7 @@ jobs:
         run: npm run build
 
       - name: Commit and sign version updates
-        if: success() && !startsWith(github.ref, 'refs/tags/')
+        if: success() && !startsWith(github.ref, 'refs/tags/') && ${{ secrets.GPG_PRIVATE_KEY != '' }}
         run: |
           if git diff --quiet; then
             echo "No changes to commit"
@@ -97,7 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create signed tag
-        if: success() && !startsWith(github.ref, 'refs/tags/')
+        if: success() && !startsWith(github.ref, 'refs/tags/') && ${{ secrets.GPG_PRIVATE_KEY != '' }}
         run: |
           VERSION=$(node -e "console.log(require('./package.json').version)")
           TAG="v${VERSION}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
       contents: write
       id-token: write
       packages: write
+    env:
+      HAS_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY != '' }}
 
     steps:
       - uses: actions/checkout@v5
@@ -39,7 +41,7 @@ jobs:
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: env.HAS_GPG_PRIVATE_KEY == 'true'
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -85,7 +87,7 @@ jobs:
         run: npm run build
 
       - name: Commit and sign version updates
-        if: success() && !startsWith(github.ref, 'refs/tags/') && ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: success() && !startsWith(github.ref, 'refs/tags/') && env.HAS_GPG_PRIVATE_KEY == 'true'
         run: |
           if git diff --quiet; then
             echo "No changes to commit"
@@ -98,7 +100,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create signed tag
-        if: success() && !startsWith(github.ref, 'refs/tags/') && ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: success() && !startsWith(github.ref, 'refs/tags/') && env.HAS_GPG_PRIVATE_KEY == 'true'
         run: |
           VERSION=$(node -e "console.log(require('./package.json').version)")
           TAG="v${VERSION}"


### PR DESCRIPTION
- Add 'if' condition to Import GPG key step to skip if GPG_PRIVATE_KEY secret is empty
- Make 'Commit and sign version updates' conditional on GPG secret availability
- Make 'Create signed tag' conditional on GPG secret availability
- Prevents workflow failure when GPG secrets are not configured in repository

This allows the publish workflow to proceed without GPG signing when secrets are unavailable, while still supporting GPG-signed commits and tags when the secrets are properly configured in GitHub repository settings.
